### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Layrry is not available on Maven Central yet.
 In order to use it, build it from source like so:
 
 ```
-mvn clean install
+mvn package
 ```
 
 Java 11 or later is needed in order to do so.


### PR DESCRIPTION
Running instructions point to a single JAR file with dependencies included, technically speaking there's no need to install artifacts to the local repository to generate such JAR file.