### PR TITLE
Add TOML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,34 @@ main:
   class: com.example.app.App
 ```
 
+Alternatively you may use TOML instead of YAML
+
+```toml
+[layers.log]
+  modules = [
+    "org.apache.logging.log4j:log4j-api:jar:2.13.1",
+    "org.apache.logging.log4j:log4j-core:jar:2.13.1",
+    "com.example.it:it-logconfig:1.0.0"]
+[layers.foo]
+  parents = ["log"]
+  modules = [
+    "com.example.it:it-greeter:1.0.0",
+    "com.example.it:it-foo:1.0.0"]
+[layers.bar]
+  parents = ["log"]
+  modules = [
+    "com.example.it:it-greeter:2.0.0",
+    "com.example.it:it-bar:1.0.0"]
+[layers.app]
+  parents = ["foo", "bar"]
+  modules = ["com.example.it:it-app:1.0.0"]
+[main]
+  module = "com.example.app"
+  class = "com.example.app.App"
+```
+
+Be sure to use `.toml` as file extension to let Layrry know which format should be parsed.
+
 You can find the complete example in the tests of the Layrry project.
 
 ## Dynamic Plug-Ins

--- a/integration-test/it-runner/pom.xml
+++ b/integration-test/it-runner/pom.xml
@@ -53,17 +53,36 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <configuration>
-            <executable>java</executable>
-            <arguments>
-              <argument>-classpath</argument>
-              <classpath/>
-              <argument>org.moditect.layrry.Layrry</argument>
-              <gument>--layers-config</gument>
-              <argument>src/test/resources/layers.yml</argument>
-              <argument>Alice</argument>
-            </arguments>
-          </configuration>
+          <executions>
+            <execution>
+              <id>run-yaml</id>
+              <configuration>
+                <executable>java</executable>
+                <arguments>
+                  <argument>-classpath</argument>
+                  <classpath/>
+                  <argument>org.moditect.layrry.Layrry</argument>
+                  <argument>--layers-config</argument>
+                  <argument>src/test/resources/layers.yml</argument>
+                  <argument>Alice</argument>
+                </arguments>
+              </configuration>
+            </execution>
+            <execution>
+              <id>run-toml</id>
+              <configuration>
+                <executable>java</executable>
+                <arguments>
+                  <argument>-classpath</argument>
+                  <classpath/>
+                  <argument>org.moditect.layrry.Layrry</argument>
+                  <argument>--layers-config</argument>
+                  <argument>src/test/resources/layers.toml</argument>
+                  <argument>Alice</argument>
+                </arguments>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
     </plugins>
   </build>

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryIntegrationTest.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryIntegrationTest.java
@@ -15,15 +15,17 @@
  */
 package com.example.layrry.integrationtest;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.moditect.layrry.Layers;
+import org.moditect.layrry.Layrry;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
 
 public class LayrryIntegrationTest {
 
@@ -43,8 +45,16 @@ public class LayrryIntegrationTest {
         System.setOut(originalSysOut);
     }
 
+    private void assertOutput() {
+        String output = sysOut.toString();
+
+        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
+    }
+
     @Test
-    public void runLayers() {
+    public void runLayersFromApi() {
         Layers layers = Layers.builder()
             .layer("log")
                 .withModule("org.apache.logging.log4j:log4j-api:jar:2.13.1")
@@ -66,10 +76,24 @@ public class LayrryIntegrationTest {
 
         layers.run("com.example.app/com.example.app.App", "Alice");
 
-        String output = sysOut.toString();
+        assertOutput();
+    }
 
-        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
+    @Test
+    public void runLayersFromYaml() throws Exception {
+        Layrry.main("--layers-config",
+            Path.of("src", "test", "resources", "layers.yml").toAbsolutePath().toString(),
+            "Alice");
+
+        assertOutput();
+    }
+
+    @Test
+    public void runLayersFromToml() throws Exception {
+        Layrry.main("--layers-config",
+            Path.of("src", "test", "resources", "layers.toml").toAbsolutePath().toString(),
+            "Alice");
+
+        assertOutput();
     }
 }

--- a/integration-test/it-runner/src/test/resources/layers.toml
+++ b/integration-test/it-runner/src/test/resources/layers.toml
@@ -1,0 +1,37 @@
+#
+#  Copyright 2020 The ModiTect authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+[layers.log]
+  modules = [
+    "org.apache.logging.log4j:log4j-api:jar:2.13.1",
+    "org.apache.logging.log4j:log4j-core:jar:2.13.1",
+    "com.example.it:it-logconfig:1.0.0"]
+[layers.foo]
+  parents = ["log"]
+  modules = [
+    "com.example.it:it-greeter:1.0.0",
+    "com.example.it:it-foo:1.0.0"]
+[layers.bar]
+  parents = ["log"]
+  modules = [
+    "com.example.it:it-greeter:2.0.0",
+    "com.example.it:it-bar:1.0.0"]
+[layers.app]
+  parents = ["foo", "bar"]
+  modules = ["com.example.it:it-app:1.0.0"]
+[main]
+  module = "com.example.app"
+  class = "com.example.app.App"

--- a/layrry-launcher/pom.xml
+++ b/layrry-launcher/pom.xml
@@ -50,6 +50,11 @@
       <version>1.26</version>
     </dependency>
     <dependency>
+      <groupId>com.github.jezza</groupId>
+      <artifactId>toml</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>1.78</version>

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/descriptor/LayersConfigParser.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/descriptor/LayersConfigParser.java
@@ -15,18 +15,32 @@
  */
 package org.moditect.layrry.internal.descriptor;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-
+import com.github.jezza.Toml;
+import com.github.jezza.TomlTable;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 public class LayersConfigParser {
 
     public static LayersConfig parseLayersConfig(Path layersConfigFile) {
+        if (layersConfigFile.getFileName().toString().endsWith(".toml")) {
+            return parseFromToml(layersConfigFile);
+        }
+
+        // YAML is the default format
+        return parseFromYaml(layersConfigFile);
+    }
+
+    private static LayersConfig parseFromYaml(Path layersConfigFile) {
         Constructor c = new Constructor(LayersConfig.class);
 
         c.setPropertyUtils(new PropertyUtils() {
@@ -47,5 +61,51 @@ public class LayersConfigParser {
         catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static LayersConfig parseFromToml(Path layersConfigFile) {
+        try (InputStream inputStream = layersConfigFile.toUri().toURL().openStream()) {
+            return readFromToml(Toml.from(inputStream));
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static LayersConfig readFromToml(TomlTable toml) {
+        LayersConfig config = new LayersConfig();
+
+        readLayers(config, (TomlTable) toml.get("layers"));
+        readMain(config, (TomlTable) toml.get("main"));
+
+        return config;
+    }
+
+    private static void readMain(LayersConfig config, TomlTable table) {
+        Main main = new Main();
+        config.setMain(main);
+
+        main.setModule(String.valueOf(table.get("module")));
+        main.setClazz(String.valueOf(table.get("class")));
+    }
+
+    private static void readLayers(LayersConfig config, TomlTable table) {
+        final Map<String, Layer> layers = new LinkedHashMap<>();
+        config.setLayers(layers);
+
+        table.entrySet().forEach(entry -> {
+            Layer layer = new Layer();
+            TomlTable layerTable = (TomlTable) entry.getValue();
+            if (layerTable.asMap().containsKey("parents")) {
+                layer.setParents((List<String>) layerTable.get("parents"));
+            }
+            if (layerTable.asMap().containsKey("modules")) {
+                layer.setModules((List<String>) layerTable.get("modules"));
+            }
+            if (layerTable.asMap().containsKey("directory")) {
+                layer.setDirectory(String.valueOf(layerTable.get("directory")));
+            }
+            layers.put(entry.getKey(), layer);
+        });
     }
 }

--- a/plugin-example/greeter-runner/src/test/resources/layers.toml
+++ b/plugin-example/greeter-runner/src/test/resources/layers.toml
@@ -1,0 +1,27 @@
+#
+#  Copyright 2020 The ModiTect authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+[layers.layrry-platform]
+  modules = ["org.moditect.layrry:layrry-platform:1.0-SNAPSHOT"]
+[layers.api]
+  modules = ["com.example.greeter:greeter-core:1.0.0"]
+  parents = ["layrry-platform"]
+[layers.plugins]
+  parents = ["api"]
+  directory = "../../../target/layers"
+[main]
+  module = "com.example.greeter.core"
+  class = "com.example.greeter.app.App"

--- a/plugin-example/readme.md
+++ b/plugin-example/readme.md
@@ -11,6 +11,13 @@ mvn clean package
 
 # Run
 To run the example app, use the following command:
+
+With **YAML** configuration
 ```
 java -jar ../layrry-launcher/target/layrry-launcher-1.0-SNAPSHOT-jar-with-dependencies.jar --layers-config greeter-runner/src/test/resources/layers.yml
+```
+
+With **TOML** configuration
+```
+java -jar ../layrry-launcher/target/layrry-launcher-1.0-SNAPSHOT-jar-with-dependencies.jar --layers-config greeter-runner/src/test/resources/layers.toml
 ```


### PR DESCRIPTION
This PR adds support for TOML as input configuration. If multiple config formats are to be supported (XML maybe?) then perhaps a refactor of `LayersConfigParser` may be warranted.

Includes a sample configuration file at plugin-example/greeter-runner/src/test/resources/layers.toml 

Let's make @brunoborges happy 😄 !