### PR TITLE
Breakdown config into API and SPI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 14
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: mvn -B install --file pom.xml

--- a/layrry-config-toml/pom.xml
+++ b/layrry-config-toml/pom.xml
@@ -26,19 +26,19 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>layrry-platform</artifactId>
+  <artifactId>layrry-config-toml</artifactId>
   <packaging>jar</packaging>
-  <name>Layrry Platform</name>
+  <name>TOML config support for Layrry</name>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>layrry-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.jezza</groupId>
+      <artifactId>toml</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-    </plugins>
-  </build>
 </project>

--- a/layrry-config-toml/src/main/java/org/moditect/layrry/config/TomlLayersConfigParser.java
+++ b/layrry-config-toml/src/main/java/org/moditect/layrry/config/TomlLayersConfigParser.java
@@ -13,15 +13,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.layrry.internal.descriptor;
+package org.moditect.layrry.config;
 
 import com.github.jezza.Toml;
 import com.github.jezza.TomlTable;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
-import org.yaml.snakeyaml.introspector.Property;
-import org.yaml.snakeyaml.introspector.PropertyUtils;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -29,47 +24,23 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class LayersConfigParser {
+public class TomlLayersConfigParser implements LayersConfigParser {
 
-    public static LayersConfig parseLayersConfig(Path layersConfigFile) {
-        if (layersConfigFile.getFileName().toString().endsWith(".toml")) {
-            return parseFromToml(layersConfigFile);
-        }
-
-        // YAML is the default format
-        return parseFromYaml(layersConfigFile);
+    @Override
+    public boolean supports(Path layersConfigFile) {
+        return layersConfigFile.getFileName().toString().endsWith(".toml");
     }
 
-    private static LayersConfig parseFromYaml(Path layersConfigFile) {
-        Constructor c = new Constructor(LayersConfig.class);
+    @Override
+    public LayersConfig parse(InputStream inputStream) throws IOException {
+        TomlTable toml = Toml.from(inputStream);
 
-        c.setPropertyUtils(new PropertyUtils() {
-            @Override
-            public Property getProperty(Class<? extends Object> type, String name) {
-                if (name.equals("class")) {
-                    name = "clazz";
-                }
-                return super.getProperty(type, name);
-            }
-        });
+        LayersConfig config = new LayersConfig();
 
-        Yaml yaml = new Yaml(c);
+        readLayers(config, (TomlTable) toml.get("layers"));
+        readMain(config, (TomlTable) toml.get("main"));
 
-        try (InputStream inputStream = layersConfigFile.toUri().toURL().openStream()) {
-            return yaml.load(inputStream);
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static LayersConfig parseFromToml(Path layersConfigFile) {
-        try (InputStream inputStream = layersConfigFile.toUri().toURL().openStream()) {
-            return readFromToml(Toml.from(inputStream));
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return config;
     }
 
     private static LayersConfig readFromToml(TomlTable toml) {

--- a/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
+++ b/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
@@ -13,10 +13,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.layrry.config;
+package org.moditect.layrry.config.toml;
 
 import com.github.jezza.Toml;
 import com.github.jezza.TomlTable;
+import org.moditect.layrry.config.Layer;
+import org.moditect.layrry.config.LayersConfig;
+import org.moditect.layrry.config.LayersConfigParser;
+import org.moditect.layrry.config.Main;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;

--- a/layrry-config-toml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
+++ b/layrry-config-toml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
@@ -1,1 +1,1 @@
-org.moditect.layrry.config.TomlLayersConfigParser
+org.moditect.layrry.config.toml.TomlLayersConfigParser

--- a/layrry-config-toml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
+++ b/layrry-config-toml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
@@ -1,0 +1,1 @@
+org.moditect.layrry.config.TomlLayersConfigParser

--- a/layrry-config-yaml/pom.xml
+++ b/layrry-config-yaml/pom.xml
@@ -26,19 +26,20 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>layrry-platform</artifactId>
+  <artifactId>layrry-config-yaml</artifactId>
   <packaging>jar</packaging>
-  <name>Layrry Platform</name>
+  <name>YAML config support for Layrry</name>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>layrry-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.26</version>
+    </dependency>
   </dependencies>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-    </plugins>
-  </build>
 </project>

--- a/layrry-config-yaml/src/main/java/org/moditect/layrry/config/YamlLayersConfigParser.java
+++ b/layrry-config-yaml/src/main/java/org/moditect/layrry/config/YamlLayersConfigParser.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.layrry.config;
+
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+public class YamlLayersConfigParser implements LayersConfigParser {
+
+    @Override
+    public boolean supports(Path layersConfigFile) {
+        return layersConfigFile.getFileName().toString().endsWith(".yml");
+    }
+
+    @Override
+    public LayersConfig parse(InputStream inputStream) throws IOException {
+        Constructor c = new Constructor(LayersConfig.class);
+
+        c.setPropertyUtils(new PropertyUtils() {
+            @Override
+            public Property getProperty(Class<? extends Object> type, String name) {
+                if (name.equals("class")) {
+                    name = "clazz";
+                }
+                return super.getProperty(type, name);
+            }
+        });
+
+        Yaml yaml = new Yaml(c);
+
+        return yaml.load(inputStream);
+    }
+
+}

--- a/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
+++ b/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
@@ -13,8 +13,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.layrry.config;
+package org.moditect.layrry.config.yaml;
 
+import org.moditect.layrry.config.LayersConfig;
+import org.moditect.layrry.config.LayersConfigParser;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.Property;

--- a/layrry-config-yaml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
+++ b/layrry-config-yaml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
@@ -1,0 +1,1 @@
+org.moditect.layrry.config.YamlLayersConfigParser

--- a/layrry-config-yaml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
+++ b/layrry-config-yaml/src/main/resources/META-INF/services/org.moditect.layrry.config.LayersConfigParser
@@ -1,1 +1,1 @@
-org.moditect.layrry.config.YamlLayersConfigParser
+org.moditect.layrry.config.yaml.YamlLayersConfigParser

--- a/layrry-config/pom.xml
+++ b/layrry-config/pom.xml
@@ -26,19 +26,8 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>layrry-platform</artifactId>
+  <artifactId>layrry-config</artifactId>
   <packaging>jar</packaging>
-  <name>Layrry Platform</name>
+  <name>Layrry Config</name>
 
-  <dependencies>
-  </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-    </plugins>
-  </build>
 </project>

--- a/layrry-config/src/main/java/org/moditect/layrry/config/Layer.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/Layer.java
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.layrry.internal.descriptor;
+package org.moditect.layrry.config;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfig.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfig.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.layrry.config;
+
+import java.util.Map;
+
+public class LayersConfig {
+
+    private Map<String, Layer> layers;
+    private Main main;
+
+    public Map<String, Layer> getLayers() {
+        return layers;
+    }
+    public void setLayers(Map<String, Layer> layers) {
+        this.layers = layers;
+    }
+
+    public Main getMain() {
+        return main;
+    }
+
+    public void setMain(Main main) {
+        this.main = main;
+    }
+
+    @Override
+    public String toString() {
+        return "LayersConfig [layers=" + layers + ", main=" + main + "]";
+    }
+}

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigLoader.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigLoader.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.layrry.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ServiceLoader;
+
+public class LayersConfigLoader {
+
+    public static LayersConfig loadConfig(Path layersConfigFile) {
+        ServiceLoader<LayersConfigParser> parsers = ServiceLoader.load(LayersConfigParser.class, LayersConfigLoader.class.getClassLoader());
+
+        for (LayersConfigParser parser : parsers) {
+            if (parser.supports(layersConfigFile)) {
+                try (InputStream inputStream = layersConfigFile.toUri().toURL().openStream()) {
+                    return parser.parse(inputStream);
+                }
+                catch (IOException e) {
+                    throw new IllegalArgumentException("Unexpected error parsing config file. " + layersConfigFile, e);
+                }
+            }
+        }
+        throw new IllegalArgumentException("Unsupported config format. " + layersConfigFile);
+    }
+
+}

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 
 /**
- * This type allows externable configuration to be expressed with a custom format.
+ * This type allows external configuration to be expressed with a custom format.
  */
 public interface LayersConfigParser {
 

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
@@ -19,10 +19,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 
+/**
+ * This type allows externable configuration to be expressed with a custom format.
+ */
 public interface LayersConfigParser {
 
+    /**
+     * Whether the given config file format is supported or not.</p>
+     * Implementors would typically look at the file extension.
+     *
+     * @param layersConfigFile the configuration file to inspect
+     * @return {@code true} if the given format is supported, {@code false} otherwise.
+     */
     boolean supports(Path layersConfigFile);
 
+    /**
+     * Reads and parses external configuration into a {@code LayersConfig} instance.
+     * @param inputStream the configuration's input source
+     * @return a configured {@code LayersConfig} instance.
+     * @throws IOException if an error occurs while reading from the {@code InputStream}.
+     */
     LayersConfig parse(InputStream inputStream) throws IOException;
 
 }

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
@@ -13,26 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.layrry.internal.descriptor;
+package org.moditect.layrry.config;
 
-public class Main {
-    private String module;
-    private String clazz;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
 
-    public String getModule() {
-        return module;
-    }
-    public void setModule(String module) {
-        this.module = module;
-    }
-    public String getClazz() {
-        return clazz;
-    }
-    public void setClazz(String clazz) {
-        this.clazz = clazz;
-    }
-    @Override
-    public String toString() {
-        return "Main [module=" + module + ", clazz=" + clazz + "]";
-    }
+public interface LayersConfigParser {
+
+    boolean supports(Path layersConfigFile);
+
+    LayersConfig parse(InputStream inputStream) throws IOException;
+
 }

--- a/layrry-config/src/main/java/org/moditect/layrry/config/Main.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/Main.java
@@ -13,32 +13,26 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.layrry.internal.descriptor;
+package org.moditect.layrry.config;
 
-import java.util.Map;
+public class Main {
+    private String module;
+    private String clazz;
 
-public class LayersConfig {
-
-    private Map<String, Layer> layers;
-    private Main main;
-
-    public Map<String, Layer> getLayers() {
-        return layers;
+    public String getModule() {
+        return module;
     }
-    public void setLayers(Map<String, Layer> layers) {
-        this.layers = layers;
+    public void setModule(String module) {
+        this.module = module;
     }
-
-    public Main getMain() {
-        return main;
+    public String getClazz() {
+        return clazz;
     }
-
-    public void setMain(Main main) {
-        this.main = main;
+    public void setClazz(String clazz) {
+        this.clazz = clazz;
     }
-
     @Override
     public String toString() {
-        return "LayersConfig [layers=" + layers + ", main=" + main + "]";
+        return "Main [module=" + module + ", clazz=" + clazz + "]";
     }
 }

--- a/layrry-launcher/pom.xml
+++ b/layrry-launcher/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.moditect.layrry</groupId>
     <artifactId>layrry-aggregator</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -32,6 +31,14 @@
   <name>Layrry Launcher</name>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>layrry-config-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>layrry-config-toml</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
@@ -43,16 +50,6 @@
     <dependency>
       <groupId>org.jboss.shrinkwrap.resolver</groupId>
       <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>1.26</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.jezza</groupId>
-      <artifactId>toml</artifactId>
-      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>
@@ -81,29 +78,29 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.2.0</version>
-          <configuration>
-            <descriptorRefs>
-              <descriptorRef>jar-with-dependencies</descriptorRef>
-            </descriptorRefs>
-            <archive>
-              <manifest>
-                <mainClass>org.moditect.layrry.Layrry</mainClass>
-              </manifest>
-            </archive>
-          </configuration>
-
-          <executions>
-            <execution>
-              <id>make-assembly</id>
-              <phase>package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <configuration>
+          <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+          <transformers>
+            <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <manifestEntries>
+                <Main-Class>org.moditect.layrry.Layrry</Main-Class>
+              </manifestEntries>
+            </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+          </transformers>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/layrry-launcher/src/main/java/org/moditect/layrry/Layrry.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/Layrry.java
@@ -21,7 +21,6 @@ import org.moditect.layrry.config.LayersConfig;
 import org.moditect.layrry.config.LayersConfigLoader;
 import org.moditect.layrry.internal.Args;
 import org.moditect.layrry.internal.LayersFactory;
-import org.moditect.layrry.config.TomlLayersConfigParser;
 
 import com.beust.jcommander.JCommander;
 

--- a/layrry-launcher/src/main/java/org/moditect/layrry/Layrry.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/Layrry.java
@@ -17,10 +17,11 @@ package org.moditect.layrry;
 
 import java.io.File;
 
+import org.moditect.layrry.config.LayersConfig;
+import org.moditect.layrry.config.LayersConfigLoader;
 import org.moditect.layrry.internal.Args;
 import org.moditect.layrry.internal.LayersFactory;
-import org.moditect.layrry.internal.descriptor.LayersConfig;
-import org.moditect.layrry.internal.descriptor.LayersConfigParser;
+import org.moditect.layrry.config.TomlLayersConfigParser;
 
 import com.beust.jcommander.JCommander;
 
@@ -47,7 +48,7 @@ public class Layrry {
             throw new IllegalArgumentException("Specified layers config file doesn't exist: " + layersConfigFile);
         }
 
-        LayersConfig layersConfig = LayersConfigParser.parseLayersConfig(layersConfigFile.toPath());
+        LayersConfig layersConfig = LayersConfigLoader.loadConfig(layersConfigFile.toPath());
         Layers layers = new LayersFactory().createLayers(layersConfig, layersConfigFile.toPath().getParent());
 
         layers.run(

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersFactory.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersFactory.java
@@ -28,8 +28,7 @@ import java.util.stream.Collectors;
 import org.moditect.layrry.LayerBuilder;
 import org.moditect.layrry.Layers;
 import org.moditect.layrry.LayersBuilder;
-import org.moditect.layrry.internal.descriptor.Layer;
-import org.moditect.layrry.internal.descriptor.LayersConfig;
+import org.moditect.layrry.config.LayersConfig;
 
 /**
  * Creates a {@link Layers} instance based on a given configuration.
@@ -40,7 +39,7 @@ public class LayersFactory {
         Map<String, List<String>> layerDirsByName = new HashMap<>();
 
         LayersBuilder builder = Layers.builder();
-        for(Entry<String, Layer> layer : layersConfig.getLayers().entrySet()) {
+        for(Entry<String, org.moditect.layrry.config.Layer> layer : layersConfig.getLayers().entrySet()) {
             if (layer.getValue().getDirectory() != null) {
                 List<String> layerNames = handleDirectoryOfLayers(layer, layersConfigDir, builder);
                 layerDirsByName.put(layer.getKey(), layerNames);
@@ -53,7 +52,7 @@ public class LayersFactory {
         return builder.build();
     }
 
-    private void handleLayer(Entry<String, Layer> layer, Map<String, List<String>> layerDirsByName,
+    private void handleLayer(Entry<String, org.moditect.layrry.config.Layer> layer, Map<String, List<String>> layerDirsByName,
             LayersBuilder builder) {
         LayerBuilder layerBuilder = builder.layer(layer.getKey());
 
@@ -77,7 +76,7 @@ public class LayersFactory {
     /**
      * Processes a directory of layers, i.e. plug-ins.
      */
-    private List<String> handleDirectoryOfLayers(Entry<String, Layer> layer,
+    private List<String> handleDirectoryOfLayers(Entry<String, org.moditect.layrry.config.Layer> layer,
             Path layersConfigDir, LayersBuilder builder) {
         Path layersDir = layersConfigDir.resolve(layer.getValue().getDirectory()).normalize();
         if (!Files.isDirectory(layersDir)) {

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
 
   <modules>
     <module>layrry-platform</module>
+    <module>layrry-config</module>
+    <module>layrry-config-yaml</module>
+    <module>layrry-config-toml</module>
     <module>layrry-launcher</module>
     <module>integration-test</module>
     <module>plugin-example</module>
@@ -45,6 +48,21 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>layrry-platform</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>layrry-config</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>layrry-config-yaml</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>layrry-config-toml</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
- provide a yaml config module
- provide a toml config module
- change single JAR generation, use shade plugin instead

Fix for #21 