### PR TITLE
#33 Dealing with initially empty plug-in directories

### DIFF
--- a/layrry-launcher/src/main/java/org/moditect/layrry/LayerBuilder.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/LayerBuilder.java
@@ -27,7 +27,5 @@ public interface LayerBuilder {
 
     LayerBuilder layer(String name);
 
-    LayerBuilder layer(String name, String derivedFrom);
-
     Layers build();
 }

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayerBuilderImpl.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayerBuilderImpl.java
@@ -64,11 +64,6 @@ public class LayerBuilderImpl implements LayerBuilder {
     }
 
     @Override
-    public LayerBuilder layer(String name, String derivedFrom) {
-        return layersBuilder.layer(name, derivedFrom);
-    }
-
-    @Override
     public Layers build() {
         return layersBuilder.build();
     }

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersBuilderImpl.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersBuilderImpl.java
@@ -15,8 +15,12 @@
  */
 package org.moditect.layrry.internal;
 
+import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.moditect.layrry.LayerBuilder;
 import org.moditect.layrry.Layers;
@@ -26,6 +30,13 @@ public class LayersBuilderImpl implements LayersBuilder {
 
     private LayerBuilderImpl currentLayer;
     private Map<String, Component> layers = new LinkedHashMap<>();
+    private Set<PluginsDirectory> pluginsDirectories = new HashSet<>();
+
+    @Override
+    public LayersBuilder pluginsDirectory(String name, Path directory, List<String> parents) {
+        pluginsDirectories.add(new PluginsDirectory(name, directory, parents));
+        return this;
+    }
 
     @Override
     public LayerBuilder layer(String name) {
@@ -52,6 +63,6 @@ public class LayersBuilderImpl implements LayersBuilder {
             addLayer(currentLayer);
         }
 
-        return new LayersImpl(layers);
+        return new LayersImpl(pluginsDirectories, layers);
     }
 }

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersFactory.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersFactory.java
@@ -62,6 +62,8 @@ public class LayersFactory {
 
         for (String parent : layer.getValue().getParents()) {
             List<String> layersFromDirectory = layerDirsByName.get(parent);
+
+            // if the parent is a plug-ins directory, add each contained plug-in as a parent
             if (layersFromDirectory != null && !layersFromDirectory.isEmpty()) {
                 for (String layerFromDirectory : layersFromDirectory) {
                     layerBuilder.withParent(layerFromDirectory);
@@ -82,6 +84,8 @@ public class LayersFactory {
         if (!Files.isDirectory(layersDir)) {
             throw new IllegalArgumentException("Specified layer directory doesn't exist: " + layersDir);
         }
+
+        builder.pluginsDirectory(layer.getKey(), layersDir, layer.getValue().getParents());
 
         ArrayList<String> layerNames = new ArrayList<String>();
         List<Path> layerDirs = getLayerDirs(layersDir);

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersImpl.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/LayersImpl.java
@@ -136,7 +136,7 @@ public class LayersImpl implements Layers {
         if (component.isPlugin()) {
             Plugin plugin = (Plugin)component;
             Path pluginDir = pluginsWorkingDir.resolve(pluginIndex++ + "-" + plugin.getName());
-            FilesHelper.copyFolder(plugin.getLayerDir(),pluginDir);
+            FilesHelper.copyFolder(plugin.getLayerDir(), pluginDir);
 
             return List.of(pluginDir);
         }

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/Plugin.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/Plugin.java
@@ -24,25 +24,15 @@ import java.util.List;
  */
 public class Plugin extends Component {
 
-    private final String derivedFrom;
     private final Path layerDir;
 
     public Plugin(String name, String derivedFrom, Path layerDir, List<String> parents) {
         super(derivedFrom + "-" + name, parents);
-        this.derivedFrom = derivedFrom;
         this.layerDir = layerDir;
-    }
-
-    public String getDerivedFrom() {
-        return derivedFrom;
     }
 
     public Path getLayerDir() {
         return layerDir;
-    }
-
-    public Path getPluginDir() {
-        return layerDir.getParent();
     }
 
     @Override

--- a/layrry-launcher/src/main/java/org/moditect/layrry/internal/PluginsDirectory.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/internal/PluginsDirectory.java
@@ -19,39 +19,23 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- * A plug-in is a layer represented by a file-system directory, containing the
- * layer's modules.
+ * A directory containing zero or more plug-ins.
  */
-public class Plugin extends Component {
+public class PluginsDirectory extends Component {
 
-    private final String derivedFrom;
-    private final Path layerDir;
+    private final Path directory;
 
-    public Plugin(String name, String derivedFrom, Path layerDir, List<String> parents) {
-        super(derivedFrom + "-" + name, parents);
-        this.derivedFrom = derivedFrom;
-        this.layerDir = layerDir;
+    public PluginsDirectory(String name, Path directory, List<String> parents) {
+        super(name, parents);
+        this.directory = directory;
     }
 
-    public String getDerivedFrom() {
-        return derivedFrom;
-    }
-
-    public Path getLayerDir() {
-        return layerDir;
-    }
-
-    public Path getPluginDir() {
-        return layerDir.getParent();
+    public Path getDirectory() {
+        return directory;
     }
 
     @Override
     public boolean isPlugin() {
-        return true;
-    }
-
-    @Override
-    public String toString() {
-        return "Plugin [layerDir=" + layerDir + "]";
+        return false;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.8</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
         </plugin>

--- a/vertx-example/layrry-links-greenkeeping/pom.xml
+++ b/vertx-example/layrry-links-greenkeeping/pom.xml
@@ -1,0 +1,77 @@
+<!--
+
+     Copyright 2020 The ModiTect authors
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.moditect.layrry</groupId>
+    <artifactId>layrry-links-example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>com.example.layrry.links</groupId>
+  <artifactId>layrry-links-greenkeeping</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <name>Layrry Links Greenkeeping Plug-in</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example.layrry.links</groupId>
+      <artifactId>layrry-links-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-assembly-plugin</artifactId>
+         <executions>
+           <execution>
+             <phase>package</phase>
+             <goals>
+               <goal>single</goal>
+             </goals>
+             <configuration>
+               <appendAssemblyId>false</appendAssemblyId>
+               <descriptors>
+                 <descriptor>src/main/assembly/assembly.xml</descriptor>
+               </descriptors>
+             </configuration>
+           </execution>
+         </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/vertx-example/layrry-links-greenkeeping/src/main/assembly/assembly.xml
+++ b/vertx-example/layrry-links-greenkeeping/src/main/assembly/assembly.xml
@@ -1,0 +1,33 @@
+<!--
+
+     Copyright 2020 The ModiTect authors
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>dist</id>
+  <includeBaseDirectory>true</includeBaseDirectory>
+
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <files>
+    <file>
+      <source> ${project.build.directory}/${project.artifactId}-${project.version}.jar</source>
+      <outputDirectory>/</outputDirectory>
+    </file>
+  </files>
+</assembly>

--- a/vertx-example/layrry-links-greenkeeping/src/main/java/com/example/layrry/links/greenkeeping/internal/GreenkeepingRouterContributor.java
+++ b/vertx-example/layrry-links-greenkeeping/src/main/java/com/example/layrry/links/greenkeeping/internal/GreenkeepingRouterContributor.java
@@ -1,0 +1,87 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.links.greenkeeping.internal;
+
+import com.example.layrry.links.core.spi.RouterContributor;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class GreenkeepingRouterContributor implements RouterContributor {
+
+    private GreenkeepingService greenkeepingService = new GreenkeepingService();
+
+    @Override
+    public void install(Vertx vertx, RouterContributions contributions) {
+        Router router = Router.router(vertx);
+
+        router.get("/:activityID").handler(this::handleGetActivity);
+        router.put("/:activityID").handler(this::handleAddActivity);
+        router.get("/").handler(this::handleListActivities);
+
+        contributions.add("/greenkeeping-activities", router);
+    }
+
+    private void handleGetActivity(RoutingContext routingContext) {
+        String activityID = routingContext.request().getParam("activityID");
+        HttpServerResponse response = routingContext.response();
+
+        if (activityID == null) {
+            sendError(400, response);
+        }
+        else {
+            JsonObject product = greenkeepingService.getActivity(activityID);
+            if (product == null) {
+                sendError(404, response);
+            }
+            else {
+                response.putHeader("content-type", "application/json").end(product.encodePrettily());
+            }
+        }
+    }
+
+    private void handleAddActivity(RoutingContext routingContext) {
+        String activityID = routingContext.request().getParam("activityID");
+        HttpServerResponse response = routingContext.response();
+
+        if (activityID == null) {
+            sendError(400, response);
+        }
+        else {
+            JsonObject product = routingContext.getBodyAsJson();
+            if (product == null) {
+                sendError(400, response);
+            }
+            else {
+                greenkeepingService.addActivity(activityID, product);
+                response.end();
+            }
+        }
+    }
+
+    private void handleListActivities(RoutingContext routingContext) {
+        routingContext.response()
+            .putHeader("content-type", "application/json")
+            .end(greenkeepingService.getActivities().encodePrettily());
+    }
+
+    private void sendError(int statusCode, HttpServerResponse response) {
+        response.setStatusCode(statusCode).end();
+    }
+}

--- a/vertx-example/layrry-links-greenkeeping/src/main/java/com/example/layrry/links/greenkeeping/internal/GreenkeepingService.java
+++ b/vertx-example/layrry-links-greenkeeping/src/main/java/com/example/layrry/links/greenkeeping/internal/GreenkeepingService.java
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.links.greenkeeping.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class GreenkeepingService {
+
+    private Map<String, JsonObject> activities = new HashMap<>();
+
+    public GreenkeepingService() {
+        setUpInitialData();
+    }
+
+    public JsonObject getActivity(String activityId) {
+        return activities.get(activityId);
+    }
+
+    public void addActivity(String activityId, JsonObject activity) {
+        activities.put(activityId, activity);
+    }
+
+    public JsonArray getActivities() {
+        JsonArray array = new JsonArray();
+        activities.forEach((k, v) -> array.add(v));
+        return array;
+    }
+
+    private void setUpInitialData() {
+        addActivity(new JsonObject().put("id", "123").put("name", "Sand Front 9").put("date", "2020-09-17"));
+        addActivity(new JsonObject().put("id", "456").put("name", "Mow Roughs ").put("date", "2020-09-18"));
+    }
+
+    private void addActivity(JsonObject activity) {
+        activities.put(activity.getString("id"), activity);
+    }
+}

--- a/vertx-example/layrry-links-greenkeeping/src/main/java/module-info.java
+++ b/vertx-example/layrry-links-greenkeeping/src/main/java/module-info.java
@@ -1,3 +1,6 @@
+import com.example.layrry.links.core.spi.RouterContributor;
+import com.example.layrry.links.greenkeeping.internal.GreenkeepingRouterContributor;
+
 /**
  *  Copyright 2020 The ModiTect authors
  *
@@ -13,21 +16,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.layrry;
 
-import java.nio.file.Path;
-import java.util.List;
-
-/**
- * Builds a hierarchy of layers.
- */
-public interface LayersBuilder {
-
-    LayersBuilder pluginsDirectory(String name, Path directory, List<String> parents);
-
-    LayerBuilder layer(String name);
-
-    LayerBuilder layer(String name, String derivedFrom);
-
-    Layers build();
+module com.example.layrry.links.greenkeeping {
+    requires org.moditect.layrry.platform;
+    requires com.example.layrry.links.core;
+    provides RouterContributor with GreenkeepingRouterContributor;
 }

--- a/vertx-example/layrry-links-runner/pom.xml
+++ b/vertx-example/layrry-links-runner/pom.xml
@@ -76,6 +76,23 @@
       </plugins>
     </pluginManagement>
     <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-antrun-plugin</artifactId>
+      <executions>
+        <execution>
+          <phase>generate-test-resources</phase>
+          <configuration>
+            <target>
+              <mkdir dir="${project.build.directory}/route-plugins2" />
+            </target>
+          </configuration>
+          <goals>
+            <goal>run</goal>
+          </goals>
+        </execution>
+    </executions>
+    </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -94,7 +111,7 @@
                   <version>1.0.0</version>
                   <type>tar.gz</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${project.build.directory}/route-plugins</outputDirectory>
+                  <outputDirectory>${project.build.directory}/route-plugins1</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>
@@ -118,6 +135,25 @@
               </artifactItems>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-greenkeeping-plugin</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.example.layrry.links</groupId>
+                  <artifactId>layrry-links-greenkeeping</artifactId>
+                  <version>1.0.0</version>
+                  <type>tar.gz</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/plugins-prepared</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -126,7 +162,8 @@
         <configuration>
           <systemPropertyVariables>
             <layersConfig>${project.basedir}/src/test/resources/layers.yml</layersConfig>
-            <pluginDir>${project.build.directory}/route-plugins</pluginDir>
+            <pluginDir1>${project.build.directory}/route-plugins1</pluginDir1>
+            <pluginDir2>${project.build.directory}/route-plugins2</pluginDir2>
             <preparedPluginDir>${project.build.directory}/plugins-prepared</preparedPluginDir>
           </systemPropertyVariables>
           <argLine>--enable-preview</argLine>

--- a/vertx-example/layrry-links-runner/src/test/resources/layers.yml
+++ b/vertx-example/layrry-links-runner/src/test/resources/layers.yml
@@ -37,11 +37,16 @@ layers:
     parents:
       - "log"
       - "vertx"
-  plugins:
+  plugins1:
     parents:
       - "platform"
       - "log"
-    directory: ../../../target/route-plugins
+    directory: ../../../target/route-plugins1
+  plugins2:
+    parents:
+      - "platform"
+      - "log"
+    directory: ../../../target/route-plugins2
 main:
   module: com.example.layrry.links.core
   class: com.example.layrry.links.core.LayrryLinks

--- a/vertx-example/pom.xml
+++ b/vertx-example/pom.xml
@@ -40,6 +40,7 @@
     <module>layrry-links-core</module>
     <module>layrry-links-membership</module>
     <module>layrry-links-tournament</module>
+    <module>layrry-links-greenkeeping</module>
     <module>layrry-links-runner</module>
   </modules>
 


### PR DESCRIPTION
Hey @aalmiray, so this addresses the issue with initially empty plug-in directories. The implementation is rather convoluted and I'm not 100% with it, but it does the job. Filing this PR for your review and to get you unstuck with the JavaFx example. 

Eventually I hope we can simply this all a bit, but perhaps as part of a separate refactoring PR. The model was originally not aware of plug-in directories themselves, only of plug-ins (= layers) contained in such directory, which is why there was no watcher registered to initially empty plug-in directories; this is bolted onto the model now, but it all feels more complex than it could be perhaps.