### PR TITLE
First draft at remote layer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ You can find the complete example in the tests of the Layrry project.
 
 The Layrry Launcher accepts the following arguments:
 
+ * --basedir: The base directory from which plugin directories will be resolved. Layrry will use the parent directory of 
+ the layers config file if this value is not set.
  * --layers-config: Path to the layers config file. The file must use any of the supported config formats. REQUIRED.
  * --properties: Path to additional properties in Java `.properties` format. These properties will be used to replace value
  placeholders found in the layers config file. OPTIONAL.
@@ -187,7 +189,6 @@ In order to do so, the module _org.moditect.layrry:layrry-platform_  must be add
 
 ```java
 public interface PluginLifecycleListener {
-
     void pluginAdded(PluginDescriptor plugin);
 
     void pluginRemoved(PluginDescriptor plugin);
@@ -309,6 +310,57 @@ This application can be launched as
 
 ```
 layrry-launcher-1.0-SNAPSHOT-all.jar --layers-config layers.toml --properties versions.properties
+```
+
+## Remote Configuration
+
+Layrry supports loading external configuration files (inputs to `--layers-config` and `--properties`) both from local and
+remote sources. For example, the previous `layers.toml` and `versions.properties` files could be accessed from a remote server
+that exposes those resources via HTTPS, such as
+
+```sh
+layrry-launcher-1.0-SNAPSHOT-all.jar \
+  --basedir /home/user/joe \
+  --layers-config https://server:port/path/to/layers.toml \
+  --properties https://server:port/path/to/versions.properties
+```
+
+It's important to note that setting the `--basedir` config flag is more important when remote layer configuration is in use,
+as that ensures plugin directories will be resolved from the same location, otherwise the basedir location will be inferred
+as `System.getProperty("user.dir")` which may produce unexpected results when invoked from different locations.
+
+Plugin directories are always local, even if defined in remote layer configuration files. You may mix remote and local
+resources as you deem necessary, that is, the following combinations are valid:
+
+**All remote**
+```sh
+layrry-launcher-1.0-SNAPSHOT-all.jar \
+  --basedir /home/user/joe \
+  --layers-config https://server:port/path/to/layers.toml \
+  --properties https://server:port/path/to/versions.properties
+```
+
+**All local**
+```sh
+layrry-launcher-1.0-SNAPSHOT-all.jar \
+  --basedir /home/user/joe \
+  --layers-config layers.toml \
+  --properties versions.properties
+```
+
+**Mixed**
+```sh
+layrry-launcher-1.0-SNAPSHOT-all.jar \
+  --basedir /home/user/joe \
+  --layers-config https://server:port/path/to/layers.toml \
+  --properties versions.properties
+```
+
+```sh
+layrry-launcher-1.0-SNAPSHOT-all.jar \
+  --basedir /home/user/joe \
+  --layers-config layers.toml \
+  --properties https://server:port/path/to/versions.properties
 ```
 
 ## Using the Layrry API

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ repodir
   \-- org
        \-- random
            \-- bar
-               \-- 1.0.0
+               \-- 2.0.0
                    \-- bar-2.0.0.jar
 ```
 

--- a/integration-test/it-runner/pom.xml
+++ b/integration-test/it-runner/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/AbstractIntegrationTestCase.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/AbstractIntegrationTestCase.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.integrationtest;
+
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractIntegrationTestCase {
+    private ByteArrayOutputStream sysOut;
+    private PrintStream originalSysOut;
+
+    @Before
+    public void setupSysOut() {
+        sysOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(sysOut));
+
+        originalSysOut = System.out;
+    }
+
+    @After
+    public void restoreSysOut() {
+        System.setOut(originalSysOut);
+    }
+
+    protected void assertOutput() {
+        String output = sysOut.toString();
+
+        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
+    }
+}

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/AbstractRemoteIntegrationTestCase.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/AbstractRemoteIntegrationTestCase.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.integrationtest;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.junit.AfterClass;
+
+import java.nio.file.Path;
+
+public abstract class AbstractRemoteIntegrationTestCase extends AbstractIntegrationTestCase {
+    protected static String serverUri;
+    private static Server server;
+
+    protected static void startServer(ResourceHandler resource_handler) throws Exception {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        resource_handler.setDirectoriesListed(true);
+        resource_handler.setResourceBase(Path.of("src", "test", "resources").toAbsolutePath().toString());
+
+        HandlerList handlers = new HandlerList();
+        handlers.setHandlers(new Handler[]{resource_handler, new DefaultHandler()});
+        server.setHandler(handlers);
+
+        server.start();
+
+        String host = connector.getHost();
+        if (host == null) {
+            host = "localhost";
+        }
+        int port = connector.getLocalPort();
+        serverUri = String.format("http://%s:%d/", host, port);
+    }
+
+    @AfterClass
+    public static void stopServer() throws Exception {
+        server.stop();
+    }
+}

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/ContentDispositionRemoteIntegrationTest.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/ContentDispositionRemoteIntegrationTest.java
@@ -1,0 +1,128 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.integrationtest;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.moditect.layrry.launcher.LayrryLauncher;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+// Tests remote layers with "Content-Disposition" header
+public class ContentDispositionRemoteIntegrationTest {
+
+    private static Server server;
+    private static String serverUri;
+    private ByteArrayOutputStream sysOut;
+    private PrintStream originalSysOut;
+
+    private static class MyResourceHandler extends ResourceHandler{
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+            String[] paths = request.getPathInfo().split("/");
+            response.setHeader("Content-Disposition","attachment; filename="+paths[paths.length-1]);
+            super.handle(target, baseRequest, request, response);
+        }
+    }
+
+    @BeforeClass
+    public static void startJetty() throws Exception {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        ResourceHandler resource_handler = new MyResourceHandler();
+        resource_handler.setDirectoriesListed(true);
+        resource_handler.setResourceBase(Path.of("src", "test", "resources").toAbsolutePath().toString());
+
+        HandlerList handlers = new HandlerList();
+        handlers.setHandlers(new Handler[]{resource_handler, new DefaultHandler()});
+        server.setHandler(handlers);
+
+        server.start();
+
+        String host = connector.getHost();
+        if (host == null) {
+            host = "localhost";
+        }
+        int port = connector.getLocalPort();
+        serverUri = String.format("http://%s:%d/", host, port);
+    }
+
+    @AfterClass
+    public static void stopJetty() throws Exception {
+        server.stop();
+    }
+
+    @Before
+    public void setupSysOut() {
+        sysOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(sysOut));
+
+        originalSysOut = System.out;
+    }
+
+    @After
+    public void restoreSysOut() {
+        System.setOut(originalSysOut);
+    }
+
+    private void assertOutput() {
+        String output = sysOut.toString();
+
+        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
+    }
+
+    @Test
+    public void runLayersFromYaml() throws Exception {
+        LayrryLauncher.launch("--layers-config",
+            serverUri + "layers.yml",
+            "Alice");
+
+        assertOutput();
+    }
+
+    @Test
+    public void runLayersFromToml() throws Exception {
+        LayrryLauncher.launch("--layers-config",
+            serverUri + "layers.toml",
+            "Alice");
+
+        assertOutput();
+    }
+}

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/ContentNegotiationRemoteIntegrationTest.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/ContentNegotiationRemoteIntegrationTest.java
@@ -1,0 +1,128 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.integrationtest;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.moditect.layrry.launcher.LayrryLauncher;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+public class ContentNegotiationRemoteIntegrationTest {
+
+    private static Server server;
+    private static String serverUri;
+    private ByteArrayOutputStream sysOut;
+    private PrintStream originalSysOut;
+
+    @BeforeClass
+    public static void startJetty() throws Exception {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        ResourceHandler resource_handler = new MyResourceHandler();
+        resource_handler.setDirectoriesListed(true);
+        resource_handler.setResourceBase(Path.of("src", "test", "resources").toAbsolutePath().toString());
+
+        HandlerList handlers = new HandlerList();
+        handlers.setHandlers(new Handler[]{resource_handler, new DefaultHandler()});
+        server.setHandler(handlers);
+
+        server.start();
+
+        String host = connector.getHost();
+        if (host == null) {
+            host = "localhost";
+        }
+        int port = connector.getLocalPort();
+        serverUri = String.format("http://%s:%d/", host, port);
+    }
+
+    private static class MyResourceHandler extends ResourceHandler {
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+            String[] paths = request.getQueryString().split("=");
+            String extension = paths[paths.length - 1];
+            baseRequest.setPathInfo(baseRequest.getPathInfo() + "." + extension);
+            response.setHeader("Content-Type", "text/vnd." + ("yml".equals(extension) ? "yaml" : extension));
+            super.handle(target, baseRequest, request, response);
+        }
+    }
+
+    @AfterClass
+    public static void stopJetty() throws Exception {
+        server.stop();
+    }
+
+    @Before
+    public void setupSysOut() {
+        sysOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(sysOut));
+
+        originalSysOut = System.out;
+    }
+
+    @After
+    public void restoreSysOut() {
+        System.setOut(originalSysOut);
+    }
+
+    private void assertOutput() {
+        String output = sysOut.toString();
+
+        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
+    }
+
+    @Test
+    public void runLayersFromYaml() throws Exception {
+        LayrryLauncher.launch("--layers-config",
+            serverUri + "layers?type=yml",
+            "Alice");
+
+        assertOutput();
+    }
+
+    @Test
+    public void runLayersFromToml() throws Exception {
+        LayrryLauncher.launch("--layers-config",
+            serverUri + "layers?type=toml",
+            "Alice");
+
+        assertOutput();
+    }
+}

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/ContentNegotiationRemoteIntegrationTest.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/ContentNegotiationRemoteIntegrationTest.java
@@ -15,16 +15,8 @@
  */
 package com.example.layrry.integrationtest;
 
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.moditect.layrry.launcher.LayrryLauncher;
@@ -32,46 +24,15 @@ import org.moditect.layrry.launcher.LayrryLauncher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Path;
 
-import static org.junit.Assert.assertTrue;
-
-public class ContentNegotiationRemoteIntegrationTest {
-
-    private static Server server;
-    private static String serverUri;
-    private ByteArrayOutputStream sysOut;
-    private PrintStream originalSysOut;
-
+public class ContentNegotiationRemoteIntegrationTest extends AbstractRemoteIntegrationTestCase{
     @BeforeClass
-    public static void startJetty() throws Exception {
-        server = new Server();
-        ServerConnector connector = new ServerConnector(server);
-        connector.setPort(0);
-        server.addConnector(connector);
-
-        ResourceHandler resource_handler = new MyResourceHandler();
-        resource_handler.setDirectoriesListed(true);
-        resource_handler.setResourceBase(Path.of("src", "test", "resources").toAbsolutePath().toString());
-
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[]{resource_handler, new DefaultHandler()});
-        server.setHandler(handlers);
-
-        server.start();
-
-        String host = connector.getHost();
-        if (host == null) {
-            host = "localhost";
-        }
-        int port = connector.getLocalPort();
-        serverUri = String.format("http://%s:%d/", host, port);
+    public static void startServer() throws Exception {
+        startServer(new ContentNegotationResourceHandler());
     }
 
-    private static class MyResourceHandler extends ResourceHandler {
+    private static class ContentNegotationResourceHandler extends ResourceHandler {
         @Override
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
             String[] paths = request.getQueryString().split("=");
@@ -80,32 +41,6 @@ public class ContentNegotiationRemoteIntegrationTest {
             response.setHeader("Content-Type", "text/vnd." + ("yml".equals(extension) ? "yaml" : extension));
             super.handle(target, baseRequest, request, response);
         }
-    }
-
-    @AfterClass
-    public static void stopJetty() throws Exception {
-        server.stop();
-    }
-
-    @Before
-    public void setupSysOut() {
-        sysOut = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(sysOut));
-
-        originalSysOut = System.out;
-    }
-
-    @After
-    public void restoreSysOut() {
-        System.setOut(originalSysOut);
-    }
-
-    private void assertOutput() {
-        String output = sysOut.toString();
-
-        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
     }
 
     @Test

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryIntegrationIT.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryIntegrationIT.java
@@ -21,8 +21,9 @@ import org.moditect.layrry.Resolvers;
 import org.moditect.layrry.launcher.LayrryLauncher;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
-public class LayrryIntegrationTest extends AbstractIntegrationTestCase {
+public class LayrryIntegrationIT extends AbstractIntegrationTestCase {
     @Test
     public void runLayersFromApi() {
         Layers layers = Layers.builder()

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryIntegrationIT.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryIntegrationIT.java
@@ -15,46 +15,14 @@
  */
 package com.example.layrry.integrationtest;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.moditect.layrry.Layers;
 import org.moditect.layrry.Resolvers;
 import org.moditect.layrry.launcher.LayrryLauncher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
-import static org.junit.Assert.assertTrue;
-
-public class LayrryIntegrationIT {
-
-    private ByteArrayOutputStream sysOut;
-    private PrintStream originalSysOut;
-
-    @Before
-    public void setupSysOut() {
-        sysOut = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(sysOut));
-
-        originalSysOut = System.out;
-    }
-
-    @After
-    public void restoreSysOut() {
-        System.setOut(originalSysOut);
-    }
-
-    private void assertOutput() {
-        String output = sysOut.toString();
-
-        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
-    }
-
+public class LayrryIntegrationTest extends AbstractIntegrationTestCase {
     @Test
     public void runLayersFromApi() {
         Layers layers = Layers.builder()
@@ -80,33 +48,33 @@ public class LayrryIntegrationIT {
 
         assertOutput();
     }
-
+    
     @Test
     public void runLayersFromApiWithFlatRepository() {
         Layers layers = Layers.builder()
-            .resolve(Resolvers.remote().enabled(false))
-            .resolve(Resolvers.local()
-                .withLocalRepo("flat", Paths.get("target/repositories/flat").toAbsolutePath(), "flat"))
-            .layer("log")
-                .withModule("org.apache.logging.log4j:log4j-api:2.13.1")
-                .withModule("org.apache.logging.log4j:log4j-core:2.13.1")
-                .withModule("com.example.it:it-logconfig:1.0.0")
-            .layer("foo")
-                .withParent("log")
-                .withModule("com.example.it:it-greeter:1.0.0")
-                .withModule("com.example.it:it-foo:1.0.0")
-            .layer("bar")
-                .withParent("log")
-                .withModule("com.example.it:it-greeter:2.0.0")
-                .withModule("com.example.it:it-bar:1.0.0")
-            .layer("app")
-                .withParent("foo")
-                .withParent("bar")
-                .withModule("com.example.it:it-app:1.0.0")
-            .build();
-
+        .resolve(Resolvers.remote().enabled(false))
+        .resolve(Resolvers.local()
+                 .withLocalRepo("flat", Paths.get("target/repositories/flat").toAbsolutePath(), "flat"))
+        .layer("log")
+        .withModule("org.apache.logging.log4j:log4j-api:2.13.1")
+        .withModule("org.apache.logging.log4j:log4j-core:2.13.1")
+        .withModule("com.example.it:it-logconfig:1.0.0")
+        .layer("foo")
+        .withParent("log")
+        .withModule("com.example.it:it-greeter:1.0.0")
+        .withModule("com.example.it:it-foo:1.0.0")
+        .layer("bar")
+        .withParent("log")
+        .withModule("com.example.it:it-greeter:2.0.0")
+        .withModule("com.example.it:it-bar:1.0.0")
+        .layer("app")
+        .withParent("foo")
+        .withParent("bar")
+        .withModule("com.example.it:it-app:1.0.0")
+        .build();
+        
         layers.run("com.example.app/com.example.app.App", "Alice");
-
+        
         assertOutput();
     }
 

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryRemoteIntegrationTest.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryRemoteIntegrationTest.java
@@ -1,0 +1,112 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.integrationtest;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.moditect.layrry.launcher.LayrryLauncher;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+public class LayrryRemoteIntegrationTest {
+
+    private static Server server;
+    private static String serverUri;
+    private ByteArrayOutputStream sysOut;
+    private PrintStream originalSysOut;
+
+    @BeforeClass
+    public static void startJetty() throws Exception {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        ResourceHandler resource_handler = new ResourceHandler();
+        resource_handler.setDirectoriesListed(true);
+        resource_handler.setResourceBase(Path.of("src", "test", "resources").toAbsolutePath().toString());
+
+        HandlerList handlers = new HandlerList();
+        handlers.setHandlers(new Handler[]{resource_handler, new DefaultHandler()});
+        server.setHandler(handlers);
+
+        server.start();
+
+        String host = connector.getHost();
+        if (host == null) {
+            host = "localhost";
+        }
+        int port = connector.getLocalPort();
+        serverUri = String.format("http://%s:%d/", host, port);
+    }
+
+    @AfterClass
+    public static void stopJetty() throws Exception {
+        server.stop();
+    }
+
+    @Before
+    public void setupSysOut() {
+        sysOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(sysOut));
+
+        originalSysOut = System.out;
+    }
+
+    @After
+    public void restoreSysOut() {
+        System.setOut(originalSysOut);
+    }
+
+    private void assertOutput() {
+        String output = sysOut.toString();
+
+        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
+        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
+    }
+
+    @Test
+    public void runLayersFromYaml() throws Exception {
+        LayrryLauncher.launch("--layers-config",
+            serverUri + "layers.yml",
+            "Alice");
+
+        assertOutput();
+    }
+
+    @Test
+    public void runLayersFromToml() throws Exception {
+        LayrryLauncher.launch("--layers-config",
+            serverUri + "layers.toml",
+            "Alice");
+
+        assertOutput();
+    }
+}

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryRemoteIntegrationTest.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryRemoteIntegrationTest.java
@@ -15,81 +15,15 @@
  */
 package com.example.layrry.integrationtest;
 
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.moditect.layrry.launcher.LayrryLauncher;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.file.Path;
-
-import static org.junit.Assert.assertTrue;
-
-public class LayrryRemoteIntegrationTest {
-
-    private static Server server;
-    private static String serverUri;
-    private ByteArrayOutputStream sysOut;
-    private PrintStream originalSysOut;
-
+public class LayrryRemoteIntegrationTest extends AbstractRemoteIntegrationTestCase{
     @BeforeClass
-    public static void startJetty() throws Exception {
-        server = new Server();
-        ServerConnector connector = new ServerConnector(server);
-        connector.setPort(0);
-        server.addConnector(connector);
-
-        ResourceHandler resource_handler = new ResourceHandler();
-        resource_handler.setDirectoriesListed(true);
-        resource_handler.setResourceBase(Path.of("src", "test", "resources").toAbsolutePath().toString());
-
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[]{resource_handler, new DefaultHandler()});
-        server.setHandler(handlers);
-
-        server.start();
-
-        String host = connector.getHost();
-        if (host == null) {
-            host = "localhost";
-        }
-        int port = connector.getLocalPort();
-        serverUri = String.format("http://%s:%d/", host, port);
-    }
-
-    @AfterClass
-    public static void stopJetty() throws Exception {
-        server.stop();
-    }
-
-    @Before
-    public void setupSysOut() {
-        sysOut = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(sysOut));
-
-        originalSysOut = System.out;
-    }
-
-    @After
-    public void restoreSysOut() {
-        System.setOut(originalSysOut);
-    }
-
-    private void assertOutput() {
-        String output = sysOut.toString();
-
-        assertTrue(output.contains("com.example.foo.Foo - Hello, Alice from Foo (Greeter 1.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Hello, Alice from Bar (Greeter 2.0.0)"));
-        assertTrue(output.contains("com.example.bar.Bar - Good bye, Alice from Bar (Greeter 2.0.0)"));
+    public static void startServer() throws Exception {
+        startServer(new ResourceHandler());
     }
 
     @Test

--- a/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryRemoteIntegrationTest.java
+++ b/integration-test/it-runner/src/test/java/com/example/layrry/integrationtest/LayrryRemoteIntegrationTest.java
@@ -43,4 +43,15 @@ public class LayrryRemoteIntegrationTest extends AbstractRemoteIntegrationTestCa
 
         assertOutput();
     }
+
+    @Test
+    public void runVersionedLayersFromYaml() throws Exception {
+        LayrryLauncher.launch("--layers-config",
+            serverUri + "layers-versioned.yml",
+            "--properties",
+            serverUri + "versions.properties",
+            "Alice");
+
+        assertOutput();
+    }
 }

--- a/integration-test/it-runner/src/test/resources/layers-versioned.yml
+++ b/integration-test/it-runner/src/test/resources/layers-versioned.yml
@@ -1,0 +1,43 @@
+#
+#  Copyright 2020 The ModiTect authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+layers:
+  log:
+    modules:
+      - "org.apache.logging.log4j:log4j-api:{{log4jVersion}}"
+      - "org.apache.logging.log4j:log4j-core:{{log4jVersion}}"
+      - "com.example.it:it-logconfig:{{appVersion}}"
+  foo:
+    parents:
+      - "log"
+    modules:
+      - "com.example.it:it-greeter:1.0.0"
+      - "com.example.it:it-foo:{{appVersion}}"
+  bar:
+    parents:
+      - "log"
+    modules:
+      - "com.example.it:it-greeter:2.0.0"
+      - "com.example.it:it-bar:{{appVersion}}"
+  app:
+    parents:
+      - "foo"
+      - "bar"
+    modules:
+      - "com.example.it:it-app:{{appVersion}}"
+main:
+  module: com.example.app
+  class: com.example.app.App

--- a/integration-test/it-runner/src/test/resources/versions.properties
+++ b/integration-test/it-runner/src/test/resources/versions.properties
@@ -1,0 +1,18 @@
+#
+#  Copyright 2020 The ModiTect authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+log4jVersion = 2.13.1
+appVersion   = 1.0.0

--- a/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
+++ b/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
@@ -34,6 +34,21 @@ import java.util.Map;
 public class TomlLayersConfigParser implements LayersConfigParser {
 
     @Override
+    public String[] getSupportedMimeTypes() {
+        return new String[] {
+            "text/toml",
+            "text/x-toml",
+            "application/toml",
+            "application/x-toml"
+        };
+    }
+
+    @Override
+    public String getPreferredFileExtension() {
+        return "toml";
+    }
+
+    @Override
     public boolean supports(Path layersConfigFile) {
         return layersConfigFile.getFileName().toString().endsWith(".toml");
     }

--- a/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
+++ b/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
@@ -37,6 +37,8 @@ public class TomlLayersConfigParser implements LayersConfigParser {
     @Override
     public Set<String> getSupportedMimeTypes() {
         return Set.of(
+            "text/vnd.toml",
+            "application/vnd.toml",
             "text/toml",
             "text/x-toml",
             "application/toml",

--- a/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
+++ b/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
@@ -30,17 +30,18 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TomlLayersConfigParser implements LayersConfigParser {
 
     @Override
-    public String[] getSupportedMimeTypes() {
-        return new String[] {
+    public Set<String> getSupportedMimeTypes() {
+        return Set.of(
             "text/toml",
             "text/x-toml",
             "application/toml",
             "application/x-toml"
-        };
+        );
     }
 
     @Override

--- a/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
+++ b/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
@@ -32,6 +32,8 @@ public class YamlLayersConfigParser implements LayersConfigParser {
     @Override
     public Set<String> getSupportedMimeTypes() {
         return Set.of(
+            "text/vnd.yaml",
+            "application/vnd.yaml",
             "text/yaml",
             "text/x-yaml",
             "application/yaml",

--- a/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
+++ b/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
@@ -29,6 +29,21 @@ import java.nio.file.Path;
 public class YamlLayersConfigParser implements LayersConfigParser {
 
     @Override
+    public String[] getSupportedMimeTypes() {
+        return new String[] {
+            "text/yaml",
+            "text/x-yaml",
+            "application/yaml",
+            "application/x-yaml"
+        };
+    }
+
+    @Override
+    public String getPreferredFileExtension() {
+        return "yml";
+    }
+
+    @Override
     public boolean supports(Path layersConfigFile) {
         return layersConfigFile.getFileName().toString().endsWith(".yml");
     }

--- a/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
+++ b/layrry-config-yaml/src/main/java/org/moditect/layrry/config/yaml/YamlLayersConfigParser.java
@@ -25,17 +25,18 @@ import org.yaml.snakeyaml.introspector.PropertyUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Set;
 
 public class YamlLayersConfigParser implements LayersConfigParser {
 
     @Override
-    public String[] getSupportedMimeTypes() {
-        return new String[] {
+    public Set<String> getSupportedMimeTypes() {
+        return Set.of(
             "text/yaml",
             "text/x-yaml",
             "application/yaml",
             "application/x-yaml"
-        };
+        );
     }
 
     @Override

--- a/layrry-config/pom.xml
+++ b/layrry-config/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>
       <artifactId>compiler</artifactId>
-      <version>0.9.6</version>
+      <version>0.9.7</version>
     </dependency>
   </dependencies>
 

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigLoader.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigLoader.java
@@ -181,7 +181,7 @@ public class LayersConfigLoader {
     }
 
     private static boolean isLocalUrl(URL url) {
-        return "file".equals(url.getProtocol());
+        return "file".equalsIgnoreCase(url.getProtocol());
     }
 
     private static Path convertToPath(URL url) {

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigLoader.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigLoader.java
@@ -54,6 +54,18 @@ public class LayersConfigLoader {
         return loadConfig(layersConfigUrl, properties);
     }
 
+    public static LayersConfig loadConfig(URL layersConfigUrl, URL propertiesFileUrl) {
+        Properties properties = new Properties();
+
+        try (InputStream inputStream = propertiesFileUrl.openStream()) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unexpected error reading properties from: " + propertiesFileUrl, e);
+        }
+
+        return loadConfig(layersConfigUrl, properties);
+    }
+
     public static LayersConfig loadConfig(Path layersConfigFile) {
         return loadConfig(layersConfigFile, new Properties());
     }
@@ -65,6 +77,18 @@ public class LayersConfigLoader {
             properties.load(inputStream);
         } catch (IOException e) {
             throw new IllegalStateException("Unexpected error reading properties file: " + propertiesFile, e);
+        }
+
+        return loadConfig(layersConfigFile, properties);
+    }
+
+    public static LayersConfig loadConfig(Path layersConfigFile, URL propertiesFileUrl) {
+        Properties properties = new Properties();
+
+        try (InputStream inputStream = propertiesFileUrl.openStream()) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unexpected error reading properties from: " + propertiesFileUrl, e);
         }
 
         return loadConfig(layersConfigFile, properties);

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
@@ -25,6 +25,19 @@ import java.nio.file.Path;
 public interface LayersConfigParser {
 
     /**
+     * Returns the set of supported mime-types by this parser.
+     * Used to determine if the content of a given URL can be read by this parser.
+     * @return the set of supported mime-types by this parser, should never return {@code null}.
+     */
+    String[] getSupportedMimeTypes();
+
+    /**
+     * Returns the preferred file extension supported by this parser.
+     * @return the preferred file extension supported by this parser, should never return {@code null}.
+     */
+    String getPreferredFileExtension();
+
+    /**
      * Whether the given config file format is supported or not.</p>
      * Implementors would typically look at the file extension.
      *
@@ -36,7 +49,7 @@ public interface LayersConfigParser {
     /**
      * Reads and parses external configuration into a {@code LayersConfig} instance.
      * @param inputStream the configuration's input source
-     * @return a configured {@code LayersConfig} instance.
+     * @return a configured {@code LayersConfig} instance, should never return {@code null}.
      * @throws IOException if an error occurs while reading from the {@code InputStream}.
      */
     LayersConfig parse(InputStream inputStream) throws IOException;

--- a/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/LayersConfigParser.java
@@ -18,6 +18,7 @@ package org.moditect.layrry.config;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Set;
 
 /**
  * This type allows external configuration to be expressed with a custom format.
@@ -29,7 +30,7 @@ public interface LayersConfigParser {
      * Used to determine if the content of a given URL can be read by this parser.
      * @return the set of supported mime-types by this parser, should never return {@code null}.
      */
-    String[] getSupportedMimeTypes();
+    Set<String> getSupportedMimeTypes();
 
     /**
      * Returns the preferred file extension supported by this parser.

--- a/layrry-config/src/main/java/org/moditect/layrry/config/UrlDownloader.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/UrlDownloader.java
@@ -93,6 +93,7 @@ class UrlDownloader {
         String useSystemProxies = properties.getProperty(JAVA_NET_USE_SYSTEM_PROXIES);
         if (useSystemProxies != null && getBoolean(JAVA_NET_USE_SYSTEM_PROXIES, properties)) {
             // we're done here
+            System.setProperty(JAVA_NET_USE_SYSTEM_PROXIES, "true");
             return;
         }
 

--- a/layrry-config/src/main/java/org/moditect/layrry/config/UrlDownloader.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/UrlDownloader.java
@@ -1,0 +1,175 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.layrry.config;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.ServiceLoader;
+
+class UrlDownloader {
+    private static final String JAVA_NET_USE_SYSTEM_PROXIES = "java.net.useSystemProxies";
+
+    static Path download(URL url, Properties properties) {
+        setupProxy(properties);
+
+        try {
+            URLConnection connection = url.openConnection();
+            // default timeout is 30 seconds
+            connection.setConnectTimeout(getInteger("connection.timeout", properties, 30_000));
+            connection.connect();
+            String fileName = resolveFileName(url);
+            String fileExtension = resolveFileExtension(fileName, connection);
+            if (fileExtension != null) {
+                fileName += fileExtension;
+            }
+
+            File layersConfigFile = File.createTempFile("layrry", fileName);
+            transfer(connection.getInputStream(), new FileOutputStream(layersConfigFile), true);
+            return layersConfigFile.toPath();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unexpected error downloading layers file from " + url, e);
+        }
+    }
+
+    private static String resolveFileName(URL url) {
+        String path = url.getPath();
+        // TODO: should ending '/' be chopped?
+        // TODO: perhaps the name is defined in the headers
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        int index = path.lastIndexOf('/');
+        if (index < 0) {
+            return path;
+        }
+        return path.substring(index + 1);
+    }
+
+    private static String resolveFileExtension(String fileName, URLConnection connection) {
+        int dot = fileName.lastIndexOf('.');
+        if (dot > -1) {
+            // no need to guess the file extension
+            // we assume it's the correct one
+            return null;
+        }
+
+        String contentType = connection.getContentType();
+        ServiceLoader<LayersConfigParser> parsers = ServiceLoader.load(LayersConfigParser.class, LayersConfigLoader.class.getClassLoader());
+
+        for (LayersConfigParser parser : parsers) {
+            for (String mimeType : parser.getSupportedMimeTypes()) {
+                if (mimeType.equals(contentType)) {
+                    return "." + parser.getPreferredFileExtension();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static void setupProxy(Properties properties) {
+        String useSystemProxies = properties.getProperty(JAVA_NET_USE_SYSTEM_PROXIES);
+        if (useSystemProxies != null && getBoolean(JAVA_NET_USE_SYSTEM_PROXIES, properties)) {
+            // we're done here
+            return;
+        }
+
+        if (getBoolean("http.proxy", properties) || getBoolean("https.proxy", properties)) {
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    if (getRequestorType() == Authenticator.RequestorType.PROXY) {
+                        String protocol = getRequestingProtocol().toLowerCase();
+                        String host = properties.getProperty(protocol + ".proxyHost", "");
+                        String port = properties.getProperty(protocol + ".proxyPort", "80");
+                        String username = properties.getProperty(protocol + ".proxyUser", "");
+                        String password = properties.getProperty(protocol + ".proxyPassword", "");
+                        if (getRequestingHost().equalsIgnoreCase(host) &&
+                            Integer.parseInt(port) == getRequestingPort()) {
+                            return new PasswordAuthentication(username, password.toCharArray());
+                        }
+                    }
+                    return null;
+                }
+            });
+        }
+
+        if (getBoolean("socks.proxy", properties)) {
+            System.setProperty("socksProxyHost", properties.getProperty("socks.proxyHost"));
+            System.setProperty("socksProxyPort", properties.getProperty("socks.proxyPort"));
+            if (getBoolean("socks.proxy.auth", properties)) {
+                String username = properties.getProperty("socks.proxyUser", "");
+                String password = properties.getProperty("socks.proxyPassword", "");
+                System.setProperty("java.net.socks.username", username);
+                System.setProperty("java.net.socks.password", password);
+                Authenticator.setDefault(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(username, password.toCharArray());
+                    }
+                });
+            }
+        }
+    }
+
+    static boolean getBoolean(String name, Properties properties) {
+        try {
+            return Boolean.parseBoolean(properties.getProperty(name));
+        } catch (IllegalArgumentException | NullPointerException e) {
+            // ignored
+        }
+        return false;
+    }
+
+    static int getInteger(String name, Properties properties, int defaultValue) {
+        try {
+            return Integer.parseInt(properties.getProperty(name));
+        } catch (NumberFormatException | NullPointerException e) {
+            // ignored
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Transfers the contents of the {@link InputStream} into the {@link OutputStream}, optionally closing the stream.
+     *
+     * @param istream the input stream
+     * @param ostream the output stream
+     * @param close   whether or not to close the output stream
+     */
+    static void transfer(InputStream istream, OutputStream ostream, final boolean close) throws IOException {
+        try {
+            final byte[] bytes = new byte[2_048];
+            int read;
+            while ((read = istream.read(bytes)) != -1) {
+                ostream.write(bytes, 0, read);
+            }
+        } finally {
+            if (close) {
+                ostream.close();
+            }
+        }
+    }
+}

--- a/layrry-config/src/main/java/org/moditect/layrry/config/UrlDownloader.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/UrlDownloader.java
@@ -46,7 +46,10 @@ class UrlDownloader {
             }
 
             File layersConfigFile = File.createTempFile("layrry", fileName);
-            transfer(connection.getInputStream(), new FileOutputStream(layersConfigFile), true);
+            try (InputStream in = connection.getInputStream();
+                 OutputStream out = new FileOutputStream(layersConfigFile)) {
+                in.transferTo(out);
+            }
             return layersConfigFile.toPath();
         } catch (IOException e) {
             throw new IllegalStateException("Unexpected error downloading layers file from " + url, e);
@@ -151,26 +154,5 @@ class UrlDownloader {
             // ignored
         }
         return defaultValue;
-    }
-
-    /**
-     * Transfers the contents of the {@link InputStream} into the {@link OutputStream}, optionally closing the stream.
-     *
-     * @param istream the input stream
-     * @param ostream the output stream
-     * @param close   whether or not to close the output stream
-     */
-    static void transfer(InputStream istream, OutputStream ostream, final boolean close) throws IOException {
-        try {
-            final byte[] bytes = new byte[2_048];
-            int read;
-            while ((read = istream.read(bytes)) != -1) {
-                ostream.write(bytes, 0, read);
-            }
-        } finally {
-            if (close) {
-                ostream.close();
-            }
-        }
     }
 }

--- a/layrry-core/src/main/java/org/moditect/layrry/Layrry.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/Layrry.java
@@ -19,6 +19,7 @@ import org.moditect.layrry.config.LayersConfig;
 import org.moditect.layrry.config.LayersConfigLoader;
 import org.moditect.layrry.internal.LayersFactory;
 
+import java.net.URL;
 import java.nio.file.Path;
 
 /**
@@ -31,15 +32,27 @@ import java.nio.file.Path;
  */
 public final class Layrry {
 
-    public static void run(Path layersConfigFile, String... args) {
+    public static void run(URL layersConfigUrl, Path basedir, String... args) {
+        launch(basedir, LayersConfigLoader.loadConfig(layersConfigUrl), args);
+    }
+
+    public static void run(URL layersConfigUrl, Path basedir, Path propertiesFile, String... args) {
+        if (!propertiesFile.toFile().exists()) {
+            throw new IllegalArgumentException("Specified properties config file doesn't exist: " + propertiesFile);
+        }
+
+        launch(basedir, LayersConfigLoader.loadConfig(layersConfigUrl, propertiesFile), args);
+    }
+
+    public static void run(Path layersConfigFile, Path basedir, String... args) {
         if (!layersConfigFile.toFile().exists()) {
             throw new IllegalArgumentException("Specified layers config file doesn't exist: " + layersConfigFile);
         }
 
-        launch(layersConfigFile, LayersConfigLoader.loadConfig(layersConfigFile), args);
+        launch(basedir, LayersConfigLoader.loadConfig(layersConfigFile), args);
     }
 
-    public static void run(Path layersConfigFile, Path propertiesFile, String... args) {
+    public static void run(Path layersConfigFile, Path basedir, Path propertiesFile, String... args) {
         if (!layersConfigFile.toFile().exists()) {
             throw new IllegalArgumentException("Specified layers config file doesn't exist: " + layersConfigFile);
         }
@@ -47,11 +60,11 @@ public final class Layrry {
             throw new IllegalArgumentException("Specified properties config file doesn't exist: " + propertiesFile);
         }
 
-        launch(layersConfigFile, LayersConfigLoader.loadConfig(layersConfigFile, propertiesFile), args);
+        launch(basedir, LayersConfigLoader.loadConfig(layersConfigFile, propertiesFile), args);
     }
 
-    private static void launch(Path layersConfigFile, LayersConfig layersConfig, String... args){
-        Layers layers = new LayersFactory().createLayers(layersConfig, layersConfigFile.getParent());
+    private static void launch(Path basedir, LayersConfig layersConfig, String... args) {
+        Layers layers = new LayersFactory().createLayers(layersConfig, basedir);
 
         layers.run(layersConfig.getMain().getModule() + "/" + layersConfig.getMain().getClazz(), args);
     }

--- a/layrry-core/src/main/java/org/moditect/layrry/Layrry.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/Layrry.java
@@ -44,6 +44,10 @@ public final class Layrry {
         launch(basedir, LayersConfigLoader.loadConfig(layersConfigUrl, propertiesFile), args);
     }
 
+    public static void run(URL layersConfigUrl, Path basedir, URL propertiesFileUrl, String... args) {
+        launch(basedir, LayersConfigLoader.loadConfig(layersConfigUrl, propertiesFileUrl), args);
+    }
+
     public static void run(Path layersConfigFile, Path basedir, String... args) {
         if (!layersConfigFile.toFile().exists()) {
             throw new IllegalArgumentException("Specified layers config file doesn't exist: " + layersConfigFile);
@@ -61,6 +65,14 @@ public final class Layrry {
         }
 
         launch(basedir, LayersConfigLoader.loadConfig(layersConfigFile, propertiesFile), args);
+    }
+
+    public static void run(Path layersConfigFile, Path basedir, URL propertiesFileUrl, String... args) {
+        if (!layersConfigFile.toFile().exists()) {
+            throw new IllegalArgumentException("Specified layers config file doesn't exist: " + layersConfigFile);
+        }
+
+        launch(basedir, LayersConfigLoader.loadConfig(layersConfigFile, propertiesFileUrl), args);
     }
 
     private static void launch(Path basedir, LayersConfig layersConfig, String... args) {

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/LayersFactory.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/LayersFactory.java
@@ -39,33 +39,7 @@ public class LayersFactory {
             }
         }
 
-        return configureMaven(layersConfig, layersConfigDir, builder.build());
-    }
-
-    private Layers configureMaven(LayersConfig layersConfig, Path layersConfigDir, Layers layers) {
-        if (layersConfig.getResolve() == null) {
-            return layers;
-        }
-
-        /*
-        // configure remote
-        layers.getResolution().remote().enabled(layersConfig.getMaven().isRemote());
-        layers.getResolution().remote().workOffline(layersConfig.getMaven().isOffline());
-        layers.getResolution().remote().withMavenCentralRepo(layersConfig.getMaven().isUseMavenCentral());
-        String configFilePath = layersConfig.getMaven().getConfigFile();
-        if (configFilePath != null && !configFilePath.isEmpty()) {
-            layers.maven().remote().fromFile(layersConfigDir.resolve(configFilePath));
-        }
-
-        // configure local
-        layersConfig.getMaven().getLocalRepositories().forEach((id, repository) -> {
-            layers.maven().local().withLocalRepo(id,
-                layersConfigDir.resolve(repository.getPath()),
-                repository.getLayout());
-        });
-        */
-
-        return layers;
+        return builder.build();
     }
 
     private void handleLayer(Entry<String, org.moditect.layrry.config.Layer> layer,

--- a/layrry-launcher/pom.xml
+++ b/layrry-launcher/pom.xml
@@ -57,32 +57,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
-        <configuration>
-          <shadedArtifactAttached>true</shadedArtifactAttached>
-          <shadedClassifierName>all</shadedClassifierName>
-          <transformers>
-            <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <manifestEntries>
-                <Main-Class>${application.main.class}</Main-Class>
-              </manifestEntries>
-            </transformer>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-          </transformers>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.1.0</version>
@@ -125,6 +99,32 @@
             <phase>package</phase>
             <goals>
               <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <configuration>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <shadedClassifierName>all</shadedClassifierName>
+          <transformers>
+            <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <manifestEntries>
+                <Main-Class>${application.main.class}</Main-Class>
+              </manifestEntries>
+            </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+          </transformers>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
             </goals>
           </execution>
         </executions>

--- a/layrry-launcher/src/main/assembly/assembly.xml
+++ b/layrry-launcher/src/main/assembly/assembly.xml
@@ -28,7 +28,7 @@
     <fileSets>
         <fileSet>
             <!--
-            Apparently this variable is not availabel during assembly
+            Apparently this variable is not available during assembly
             <directory>${session.executionRootDirectory}</directory>
             -->
             <directory>${project.basedir}/../</directory>

--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
@@ -31,6 +31,8 @@ import java.nio.file.Paths;
  * <code>
  * LayrryLauncher --layers-config &lt;path/to/layrry.yml&gt;
  * LayrryLauncher --layers-config &lt;path/to/layrry.yml&gt; --properties &lt;path/to/layrry.properties&gt;
+ * LayrryLauncher --layers-config https://host/path/to/layrry.yml --properties &lt;path/to/layrry.properties&gt;
+ * LayrryLauncher --layers-config https://host/path/to/layrry.yml --properties https://host/path/to/layrry.properties
  * </code>
  */
 public final class LayrryLauncher {
@@ -47,11 +49,12 @@ public final class LayrryLauncher {
             .build()
             .parse(args);
 
-
-        File propertiesFile = arguments.getProperties();
         String[] parsedArgs = arguments.getMainArgs().toArray(new String[0]);
 
         File basedir = arguments.getBasedir();
+
+        String propertiesFile = arguments.getProperties();
+        URL propertiesFileUrl = toUrl(propertiesFile);
 
         String layersConfig = arguments.getLayersConfig();
         URL layersConfigUrl = toUrl(layersConfig);
@@ -63,8 +66,10 @@ public final class LayrryLauncher {
 
             if (null == propertiesFile) {
                 Layrry.run(layersConfigUrl, basedir.toPath(), parsedArgs);
+            } else if (null != propertiesFileUrl) {
+                Layrry.run(layersConfigUrl, basedir.toPath(), propertiesFileUrl, parsedArgs);
             } else {
-                Layrry.run(layersConfigUrl, basedir.toPath(), propertiesFile.getAbsoluteFile().toPath(), parsedArgs);
+                Layrry.run(layersConfigUrl, basedir.toPath(), Paths.get(propertiesFile).toAbsolutePath(), parsedArgs);
             }
         } else {
             Path layersConfigPath = Paths.get(layersConfig).toAbsolutePath();
@@ -76,8 +81,10 @@ public final class LayrryLauncher {
 
             if (null == propertiesFile) {
                 Layrry.run(layersConfigPath, basedirPath, parsedArgs);
+            } else if (null != propertiesFileUrl) {
+                Layrry.run(layersConfigPath, basedir.toPath(), propertiesFileUrl, parsedArgs);
             } else {
-                Layrry.run(layersConfigPath, basedirPath, propertiesFile.getAbsoluteFile().toPath(), parsedArgs);
+                Layrry.run(layersConfigPath, basedir.toPath(), Paths.get(propertiesFile).toAbsolutePath(), parsedArgs);
             }
         }
     }

--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
@@ -54,7 +54,7 @@ public final class LayrryLauncher {
         File basedir = arguments.getBasedir();
 
         String layersConfig = arguments.getLayersConfig();
-        URL layersConfigUrl = toURL(layersConfig);
+        URL layersConfigUrl = toUrl(layersConfig);
 
         if (null != layersConfigUrl) {
             if (basedir == null) {
@@ -82,7 +82,7 @@ public final class LayrryLauncher {
         }
     }
 
-    private static URL toURL(String input) {
+    private static URL toUrl(String input) {
         try {
             return new URL(input);
         } catch (MalformedURLException e) {

--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
@@ -82,9 +82,9 @@ public final class LayrryLauncher {
             if (null == propertiesFile) {
                 Layrry.run(layersConfigPath, basedirPath, parsedArgs);
             } else if (null != propertiesFileUrl) {
-                Layrry.run(layersConfigPath, basedir.toPath(), propertiesFileUrl, parsedArgs);
+                Layrry.run(layersConfigPath, basedirPath, propertiesFileUrl, parsedArgs);
             } else {
-                Layrry.run(layersConfigPath, basedir.toPath(), Paths.get(propertiesFile).toAbsolutePath(), parsedArgs);
+                Layrry.run(layersConfigPath, basedirPath, Paths.get(propertiesFile).toAbsolutePath(), parsedArgs);
             }
         }
     }

--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/internal/Args.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/internal/Args.java
@@ -15,11 +15,11 @@
  */
 package org.moditect.layrry.launcher.internal;
 
+import com.beust.jcommander.Parameter;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.beust.jcommander.Parameter;
 
 public class Args {
 
@@ -27,16 +27,19 @@ public class Args {
     private List<String> mainArgs = new ArrayList<>();
 
     @Parameter(names = "--layers-config", required = true, description = "Layers configuration file")
-    private File layersConfig;
+    private String layersConfig;
 
     @Parameter(names = "--properties", description = "Additional config properties")
     private File properties;
+
+    @Parameter(names = "--basedir", description = "Base directory for resolving relative paths")
+    private File basedir;
 
     public List<String> getMainArgs() {
         return mainArgs;
     }
 
-    public File getLayersConfig() {
+    public String getLayersConfig() {
         return layersConfig;
     }
 
@@ -44,8 +47,12 @@ public class Args {
         return properties;
     }
 
+    public File getBasedir() {
+        return basedir;
+    }
+
     @Override
     public String toString() {
-        return "Args [mainArgs=" + mainArgs + ", layersConfig=" + layersConfig + ", properties=" + properties+ "]";
+        return "Args [mainArgs=" + mainArgs + ", layersConfig=" + layersConfig + ", properties=" + properties + ", basedir=" + basedir + "]";
     }
 }

--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/internal/Args.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/internal/Args.java
@@ -30,7 +30,7 @@ public class Args {
     private String layersConfig;
 
     @Parameter(names = "--properties", description = "Additional config properties")
-    private File properties;
+    private String properties;
 
     @Parameter(names = "--basedir", description = "Base directory for resolving relative paths")
     private File basedir;
@@ -43,7 +43,7 @@ public class Args {
         return layersConfig;
     }
 
-    public File getProperties() {
+    public String getProperties() {
         return properties;
     }
 

--- a/plugin-example/greeter-runner/pom.xml
+++ b/plugin-example/greeter-runner/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -136,6 +141,7 @@
         <configuration>
           <systemPropertyVariables>
             <layersConfig>${project.basedir}/src/test/resources/layers.yml</layersConfig>
+            <basedir>${project.basedir}</basedir>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/plugin-example/greeter-runner/src/test/java/com/example/layrry/pluginexample/PluginExampleRemoteTest.java
+++ b/plugin-example/greeter-runner/src/test/java/com/example/layrry/pluginexample/PluginExampleRemoteTest.java
@@ -1,0 +1,115 @@
+/**
+ *  Copyright 2020 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.layrry.pluginexample;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.moditect.layrry.launcher.LayrryLauncher;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+public class PluginExampleRemoteTest {
+
+    private static Server server;
+    private static String serverUri;
+    private ByteArrayOutputStream sysOut;
+    private PrintStream originalSysOut;
+
+    @BeforeClass
+    public static void startJetty() throws Exception {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        ResourceHandler resource_handler = new ResourceHandler();
+        resource_handler.setDirectoriesListed(true);
+        resource_handler.setResourceBase(Path.of("src", "test", "resources").toAbsolutePath().toString());
+
+        HandlerList handlers = new HandlerList();
+        handlers.setHandlers(new Handler[]{resource_handler, new DefaultHandler()});
+        server.setHandler(handlers);
+
+        server.start();
+
+        String host = connector.getHost();
+        if (host == null) {
+            host = "localhost";
+        }
+        int port = connector.getLocalPort();
+        serverUri = String.format("http://%s:%d/", host, port);
+    }
+
+    @AfterClass
+    public static void stopJetty() throws Exception {
+        server.stop();
+    }
+
+    @Before
+    public void setupSysOut() {
+        sysOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(sysOut));
+
+        originalSysOut = System.out;
+    }
+
+    @After
+    public void restoreSysOut() {
+        System.setOut(originalSysOut);
+    }
+
+    @Test
+    public void runLayersWithYaml() throws Exception {
+        String input = "1\nBob";
+        InputStream testInput = new ByteArrayInputStream( input.getBytes("UTF-8") );
+        System.setIn(testInput);
+
+        LayrryLauncher.launch("--layers-config",  serverUri + "layers-remote.yml", "--basedir", System.getProperty("basedir"));
+
+        String output = sysOut.toString();
+
+        assertTrue("Unexpected output: " + output, output.contains("Hi, Bob"));
+    }
+
+    @Test
+    public void runLayersWithToml() throws Exception {
+        String input = "1\nBob";
+        InputStream testInput = new ByteArrayInputStream( input.getBytes("UTF-8") );
+        System.setIn(testInput);
+
+        LayrryLauncher.launch("--layers-config",  serverUri + "layers-remote.toml", "--basedir", System.getProperty("basedir"));
+
+        String output = sysOut.toString();
+
+        assertTrue("Unexpected output: " + output, output.contains("Hi, Bob"));
+    }
+}

--- a/plugin-example/greeter-runner/src/test/resources/layers-remote.toml
+++ b/plugin-example/greeter-runner/src/test/resources/layers-remote.toml
@@ -1,0 +1,27 @@
+#
+#  Copyright 2020 The ModiTect authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+[layers.layrry-platform]
+  modules = ["org.moditect.layrry:layrry-platform:1.0-SNAPSHOT"]
+[layers.api]
+  modules = ["com.example.greeter:greeter-core:1.0.0"]
+  parents = ["layrry-platform"]
+[layers.plugins]
+  parents = ["api"]
+  directory = "target/layers"
+[main]
+  module = "com.example.greeter.core"
+  class = "com.example.greeter.app.App"

--- a/plugin-example/greeter-runner/src/test/resources/layers-remote.yml
+++ b/plugin-example/greeter-runner/src/test/resources/layers-remote.yml
@@ -1,0 +1,32 @@
+#
+#  Copyright 2020 The ModiTect authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+layers:
+  layrry-platform:
+    modules:
+      - "org.moditect.layrry:layrry-platform:1.0-SNAPSHOT"
+  api:
+    modules:
+      - "com.example.greeter:greeter-core:1.0.0"
+    parents:
+      - "layrry-platform"
+  plugins:
+    parents:
+      - "api"
+    directory: target/layers
+main:
+  module: com.example.greeter.core
+  class: com.example.greeter.app.App

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
         <artifactId>slf4j-api</artifactId>
         <version>1.7.30</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>9.4.33.v20201020</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   


### PR DESCRIPTION
Fix for #37

Supports the following:
- if a `file://` is given then it runs layers locally.
- `http://` and `https://` remote layers.
- proxy support (http/https & socks). Properties must be passed using `--properties` flag.
- local plugin support with remote layers. May specify `--basedir` otherwise `System.getProperty("user.dir")` will be used as starting point.

Yet to be supported:
- remote plugins