### PR TITLE
Fix local repository resolution

### DIFF
--- a/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
+++ b/layrry-config-toml/src/main/java/org/moditect/layrry/config/toml/TomlLayersConfigParser.java
@@ -40,20 +40,13 @@ public class TomlLayersConfigParser implements LayersConfigParser {
 
     @Override
     public LayersConfig parse(InputStream inputStream) throws IOException {
-        TomlTable toml = Toml.from(inputStream);
-
-        LayersConfig config = new LayersConfig();
-
-        readLayers(config, (TomlTable) toml.get("layers"));
-        readMain(config, (TomlTable) toml.get("main"));
-        readMaven(config, (TomlTable) toml.get("maven"));
-
-        return config;
+        return readFromToml(Toml.from(inputStream));
     }
 
     private static LayersConfig readFromToml(TomlTable toml) {
         LayersConfig config = new LayersConfig();
 
+        readResolve(config, (TomlTable) toml.get("resolve"));
         readLayers(config, (TomlTable) toml.get("layers"));
         readMain(config, (TomlTable) toml.get("main"));
 
@@ -68,15 +61,15 @@ public class TomlLayersConfigParser implements LayersConfigParser {
         main.setClazz(String.valueOf(table.get("class")));
     }
 
-    private static void readMaven(LayersConfig config, TomlTable table) {
+    private static void readResolve(LayersConfig config, TomlTable table) {
         Resolve resolve = new Resolve();
         config.setResolve(resolve);
 
         if (table != null) {
             resolve.setRemote((Boolean) table.getOrDefault("remote", true));
-            resolve.setOffline((Boolean) table.getOrDefault("offline", false));
+            resolve.setWorkOffline((Boolean) table.getOrDefault("workOffline", false));
             resolve.setUseMavenCentral((Boolean) table.getOrDefault("useMavenCentral", true));
-            resolve.setConfigFile((String) table.get("configFile"));
+            resolve.setFromFile((String) table.get("fromFile"));
             readRepositories(resolve, (TomlTable) table.get("localRepositories"));
         }
     }

--- a/layrry-config/src/main/java/org/moditect/layrry/config/Resolve.java
+++ b/layrry-config/src/main/java/org/moditect/layrry/config/Resolve.java
@@ -22,9 +22,9 @@ public class Resolve {
 
     private Map<String, Repository> localRepositories = new LinkedHashMap<>();
     private boolean remote = true;
-    private boolean offline = false;
+    private boolean workOffline = false;
     private boolean useMavenCentral = true;
-    private String configFile;
+    private String fromFile;
 
     public Map<String, Repository> getLocalRepositories() {
         return localRepositories;
@@ -42,12 +42,12 @@ public class Resolve {
         this.remote = remote;
     }
 
-    public boolean isOffline() {
-        return offline;
+    public boolean isWorkOffline() {
+        return workOffline;
     }
 
-    public void setOffline(boolean offline) {
-        this.offline = offline;
+    public void setWorkOffline(boolean workOffline) {
+        this.workOffline = workOffline;
     }
 
     public boolean isUseMavenCentral() {
@@ -58,16 +58,20 @@ public class Resolve {
         this.useMavenCentral = useMavenCentral;
     }
 
-    public String getConfigFile() {
-        return configFile;
+    public String getFromFile() {
+        return fromFile;
     }
 
-    public void setConfigFile(String configFile) {
-        this.configFile = configFile;
+    public void setFromFile(String fromFile) {
+        this.fromFile = fromFile;
     }
 
     @Override
     public String toString() {
-        return "Resolve [remote=" + remote + ", offline=" + offline + ", useMavenCentral=" + useMavenCentral + ", localRepositories=" + localRepositories + "]";
+        return "Resolve [remote=" + remote +
+            ", workOffline=" + workOffline +
+            ", useMavenCentral=" + useMavenCentral +
+            ", fromFile=" + fromFile +
+            ", localRepositories=" + localRepositories + "]";
     }
 }

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/LayersImpl.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/LayersImpl.java
@@ -95,7 +95,7 @@ public class LayersImpl implements Layers {
             resolve.remote().enabled(remote.enabled());
             resolve.remote().workOffline(remote.workOffline());
             resolve.remote().withMavenCentralRepo(remote.useMavenCentral());
-            if (null != remote.configFile()) resolve.remote().fromFile(remote.configFile());
+            if (null != remote.fromFile()) resolve.remote().fromFile(remote.fromFile());
         }
 
         try {

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/LocalResolveImpl.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/LocalResolveImpl.java
@@ -32,6 +32,14 @@ public class LocalResolveImpl implements LocalResolve {
     }
 
     @Override
+    public String toString() {
+        return new StringBuilder("LocalResolve[repositories=")
+            .append(localRepositories)
+            .append("]")
+            .toString();
+    }
+
+    @Override
     public LocalResolveImpl withLocalRepo(String id, String path, String layout) {
         localRepositories.add(LocalRepositories.createLocalRepository(id, path, layout));
         return this;

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/RemoteResolveImpl.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/RemoteResolveImpl.java
@@ -24,7 +24,7 @@ public class RemoteResolveImpl implements RemoteResolve {
     private boolean enabled = true;
     private boolean workOffline;
     private boolean useMavenCentral = true;
-    private Path configFile;
+    private Path fromFile;
 
     boolean enabled() {
         return enabled;
@@ -38,8 +38,22 @@ public class RemoteResolveImpl implements RemoteResolve {
         return useMavenCentral;
     }
 
-    Path configFile() {
-        return configFile;
+    Path fromFile() {
+        return fromFile;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("RemoteResolve[enabled=")
+            .append(enabled)
+            .append(", workOffline=")
+            .append(workOffline)
+            .append(", useMavenCentral=")
+            .append(useMavenCentral)
+            .append(", fromFile=")
+            .append(fromFile)
+            .append("]")
+            .toString();
     }
 
     @Override
@@ -50,7 +64,7 @@ public class RemoteResolveImpl implements RemoteResolve {
 
     @Override
     public RemoteResolveImpl fromFile(Path file) throws IllegalArgumentException, InvalidConfigurationFileException {
-        this.configFile = file;
+        this.fromFile = file;
         return this;
     }
 

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/ArtifactUtils.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/ArtifactUtils.java
@@ -128,13 +128,30 @@ class ArtifactUtils {
     }
 
     static boolean coordinatesMatch(MavenCoordinate a, MavenCoordinate b) {
+        // Do we have an exact match?
         if (a.equals(b) && a.getVersion().equals(b.getVersion())) return true;
+
+        // Is the group missing?
         if ("*".equals(a.getGroupId()) || "*".equals(b.getGroupId())) {
-            MavenCoordinate a1 = MavenCoordinates.createCoordinate("*", a.getArtifactId(), a.getVersion(), a.getPackaging(), a.getClassifier());
-            MavenCoordinate b1 = MavenCoordinates.createCoordinate("*", b.getArtifactId(), b.getVersion(), b.getPackaging(), b.getClassifier());
-            return a1.equals(b1) && a1.getVersion().equals(b1.getVersion());
+            a = MavenCoordinates.createCoordinate("*", a.getArtifactId(), a.getVersion(), a.getPackaging(), a.getClassifier());
+            b = MavenCoordinates.createCoordinate("*", b.getArtifactId(), b.getVersion(), b.getPackaging(), b.getClassifier());
+        }
+        if (a.equals(b) && a.getVersion().equals(b.getVersion())) return true;
+
+        // We may have failed to detect a classifier on 'a' but 'b' may have it
+        String ac = a.getClassifier();
+        String bc = b.getClassifier();
+
+        if (!isBlank(bc) && isBlank(ac)) {
+            // let b.version += " " + b.classifier
+            // b.classifier = null
+            b = MavenCoordinates.createCoordinate(b.getGroupId(), b.getArtifactId(), b.getVersion() +"-"+ bc, b.getPackaging(), null);
         }
 
-        return false;
+        return a.equals(b) && a.getVersion().equals(b.getVersion());
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
     }
 }

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/ConfigurableLocalArtifactResolverSystemImpl.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/ConfigurableLocalArtifactResolverSystemImpl.java
@@ -28,6 +28,14 @@ public class ConfigurableLocalArtifactResolverSystemImpl implements Configurable
     private final Map<String, LocalRepository> localRepositories = new LinkedHashMap<>();
 
     @Override
+    public String toString() {
+        return new StringBuilder("ConfigurableLocalArtifactResolverSystem[repositories=")
+            .append(localRepositories)
+            .append("]")
+            .toString();
+    }
+
+    @Override
     public ConfigurableLocalArtifactResolverSystem withLocalRepo(String id, String path, String layout) {
         withLocalRepo(LocalRepositories.createLocalRepository(id, path, layout));
         return this;

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/DefaultLocalRepository.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/DefaultLocalRepository.java
@@ -68,6 +68,16 @@ public class DefaultLocalRepository implements LocalRepository {
     }
 
     @Override
+    public String toString() {
+        return new StringBuilder("DefaultLocalRepository[id=")
+            .append(id)
+            .append(", path=")
+            .append(path)
+            .append("]")
+            .toString();
+    }
+
+    @Override
     public String getId() {
         return id;
     }

--- a/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/FlatLocalRepository.java
+++ b/layrry-core/src/main/java/org/moditect/layrry/internal/resolver/FlatLocalRepository.java
@@ -58,6 +58,16 @@ public class FlatLocalRepository implements LocalRepository {
     }
 
     @Override
+    public String toString() {
+        return new StringBuilder("FlatLocalRepository[id=")
+            .append(id)
+            .append(", path=")
+            .append(path)
+            .append("]")
+            .toString();
+    }
+
+    @Override
     public String getId() {
         return id;
     }


### PR DESCRIPTION
Local repositories were not configured properly when external configuration (YAML/TOML) was used.
The configuration block was commented out (!!)

Also aligned config properties by s/configFile/fromFile/ and s/offline/workOffline/.

Finally, matching Maven coordinates must be more lenient, as classifiers may not be detected from local files and be used as part of the version. Must check that the requested coordinates (which may contain a classifier) could match an artifact version identified as "${version}-${classifier}" from the POV of the requested coordinates.