### PR TITLE
Add `--help` and `--version` parameters for layrry-launcher

### DIFF
--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
@@ -44,10 +44,20 @@ public final class LayrryLauncher {
     public static void launch(String... args) throws Exception {
         Args arguments = new Args();
 
-        JCommander.newBuilder()
-            .addObject(arguments)
-            .build()
-            .parse(args);
+        JCommander jCommander = JCommander.newBuilder()
+                .addObject(arguments)
+                .build();
+        jCommander.parse(args);
+
+        if (arguments.isHelp()) {
+            jCommander.usage();
+            return;
+        }
+
+        if (arguments.isVersion()) {
+            System.out.println(LayrryLauncher.class.getPackage().getImplementationVersion());
+            return;
+        }
 
         String[] parsedArgs = arguments.getMainArgs().toArray(new String[0]);
 

--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/internal/Args.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/internal/Args.java
@@ -35,6 +35,12 @@ public class Args {
     @Parameter(names = "--basedir", description = "Base directory for resolving relative paths")
     private File basedir;
 
+    @Parameter(names = "--help", description = "Show usage", help = true)
+    private boolean help;
+
+    @Parameter(names = "--version", description = "Show version", help = true)
+    private boolean version;
+
     public List<String> getMainArgs() {
         return mainArgs;
     }
@@ -51,8 +57,16 @@ public class Args {
         return basedir;
     }
 
+    public boolean isHelp() {
+        return help;
+    }
+
+    public boolean isVersion() {
+        return version;
+    }
+
     @Override
     public String toString() {
-        return "Args [mainArgs=" + mainArgs + ", layersConfig=" + layersConfig + ", properties=" + properties + ", basedir=" + basedir + "]";
+        return "Args [mainArgs=" + mainArgs + ", layersConfig=" + layersConfig + ", properties=" + properties + ", basedir=" + basedir + ", help=" + help + ", version=" + version + "]";
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,9 @@
                 <Build-Revision>${git.commit.id}</Build-Revision>
                 <Build-OS>${os.name} ${os.arch} ${os.version}</Build-OS>
               </manifestEntries>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
             </archive>
           </configuration>
         </plugin>


### PR DESCRIPTION
Add command-line parameters for layrry-launcher to show its usage (`--help`) and its version (`--version`).

```
> java -jar /path/to/layrry-launcher-1.0.0.Alpha1-all.jar --help
Usage: <main class> [options] Main arguments
  Options:
    --basedir
      Base directory for resolving relative paths
    --help
      Show usage
  * --layers-config
      Layers configuration file
    --properties
      Additional config properties
    --version
      Show version

> java -jar /path/to/layrry-launcher-1.0.0.Alpha1-all.jar --version
1.0.0.Alpha1
```