### PR TITLE
Handle usage errors

### DIFF
--- a/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
+++ b/layrry-launcher/src/main/java/org/moditect/layrry/launcher/LayrryLauncher.java
@@ -16,6 +16,7 @@
 package org.moditect.layrry.launcher;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 import org.moditect.layrry.Layrry;
 import org.moditect.layrry.launcher.internal.Args;
 
@@ -48,7 +49,13 @@ public final class LayrryLauncher {
             .programName(LayrryLauncher.class.getName())
             .addObject(arguments)
             .build();
-        jCommander.parse(args);
+
+        try {
+            jCommander.parse(args);
+        } catch (ParameterException e) {
+            jCommander.usage();
+            return;
+        }
 
         if (arguments.isHelp()) {
             jCommander.usage();


### PR DESCRIPTION
Relates to #81.
This change only outputs the help usage if an occurs when parsing command args.

LayrryLauncher could still succeed if a suitable `layers.[ext]` is found in the launching directory (code pending).